### PR TITLE
Fix increase size calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ The PVC can optionally have `resize.topolvm.io/threshold` and `resize.topolvm.io
 When the amount of free space of the volume is below `resize.topolvm.io/threshold`,
 `.spec.resources.requests.storage` is increased by `resize.topolvm.io/increase`.
 
+If `resize.topolvm.io/increase` is given as a percentage, the value is calculated as
+the current `spec.resources.requests.storage` value multiplied by the annotation value.
+
 ```yaml
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 
 # pvc-autoresizer
 
-`pvc-autoresizer` is an automatic volume resizer that edits PVCs if they have less than the specified amount of free filesystem capacity.
+`pvc-autoresizer` resizes PersistentVolumeClaims (PVCs) when the free amount of storage is below the threshold.
+It queries the volume usage metrics from Prometheus that collects metrics from `kubelet`.
+
+**Status**: beta
 
 ## Target CSI Drivers
 
@@ -38,7 +41,8 @@ kustomize build ./config/default | kubectl apply -f -
 
 ## How to use
 
-The StorageClass of the PVC to be resized must have `resize.topolvm.io/enabled: "true"` annotation.
+To allow auto volume expansion, the StorageClass of PVC need to allow volume expansion and
+have `resize.topolvm.io/enabled: "true"` annotation.
 
 ```yaml
 kind: StorageClass
@@ -48,21 +52,24 @@ metadata:
   annotations:
     resize.topolvm.io/enabled: "true" 
 provisioner: topolvm.cybozu.com
-parameters:
-  "csi.storage.k8s.io/fstype": "xfs"
-volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 ```
 
-The PVC to be resized must have `.spec.resources.limits.storage` and must be `volumeMode: Filesystem`.
+To allow auto volume expansion, the PVC to be resized need to specify the upper limit of
+volume size with `.spec.resources.limits.storage`.  The PVC must have `volumeMode: Filesystem` too.
+
 The PVC can optionally have `resize.topolvm.io/threshold` and `resize.topolvm.io/increase` annotations.
 (If they are not given, the default value is `10%`.)
+
+When the amount of free space of the volume is below `resize.topolvm.io/threshold`,
+`.spec.resources.requests.storage` is increased by `resize.topolvm.io/increase`.
 
 ```yaml
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: topolvm-pvc
+  namespace: default
   annotations:
     resize.topolvm.io/threshold: 20%
     resize.topolvm.io/increase: 20Gi
@@ -78,12 +85,7 @@ spec:
   storageClassName: topolvm-provisioner
 ```
 
-When the amount of free space of the volume is smaller than `resize.topolvm.io/threshold`,
-the `.spec.resources.requests.storage` size will be increased by `resize.topolvm.io/increase`.
-The maximum size is specified by `.spec.resources.limits.storage`.
-
-Container images
-----------------
+## Container images
 
 Container images are available on [Quay.io](https://quay.io/repository/topolvm/pvc-autoresizer)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -51,14 +51,13 @@ func subMain() error {
 		return err
 	}
 
-	pvcAutoresizer := runners.NewPVCAutoresizer(promClient, config.watchInterval, mgr.GetEventRecorderFor("pvc-autoresizer"))
-	err = pvcAutoresizer.SetupWithManager(mgr)
-	if err != nil {
+	if err := runners.SetupIndexer(mgr); err != nil {
 		setupLog.Error(err, "unable to initialize pvc autoresizer")
 		return err
 	}
-	err = mgr.Add(pvcAutoresizer)
-	if err != nil {
+
+	pvcAutoresizer := runners.NewPVCAutoresizer(promClient, config.watchInterval, mgr.GetEventRecorderFor("pvc-autoresizer"))
+	if err := mgr.Add(pvcAutoresizer); err != nil {
 		setupLog.Error(err, "unable to add autoresier to manager")
 		return err
 	}

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,17 +1,16 @@
-# Design Notes
-
+# Design notes
 
 ## Motivation
 
-PersistentVolume(PV) is used to persist the data (ex. MySQL, Elasticsearch).
-These data size will increase in the future.
-It is difficult to estimate these in advance.
-Some CSI drivers support `VolumeExpansion`. However, it's labor-intensive to manage volume size manually.
-So, PV should be automatically expanded based on PV usage.
+Resizable persistent volumes (PVs) make operations of applications easier when
+it is difficult to predict the storage size required for the applications.
+
+That said, it can be a hassle to resize them one by one manually if there are
+a lot of such persistent volumes.
 
 ## Goal
 
-- PersistentVolumeClaims(PVCs) are automatically got resized when they are running out of free space.
+- Automate resizing of persistent volumes using filesystem usage metrics.
 - Users can configure resizing parameters for each PVC.
 - Users can enable this feature only for specific StorageClasses.
 

--- a/runners/metrics_client.go
+++ b/runners/metrics_client.go
@@ -51,7 +51,6 @@ type prometheusClient struct {
 
 func (c *prometheusClient) GetMetrics(ctx context.Context) (map[types.NamespacedName]*VolumeStats, error) {
 	volumeStatsMap := make(map[types.NamespacedName]*VolumeStats)
-	var err error
 
 	usedBytes, err := c.getMetricValues(ctx, volumeUsedQuery)
 	if err != nil {
@@ -69,19 +68,18 @@ func (c *prometheusClient) GetMetrics(ctx context.Context) (map[types.Namespaced
 	}
 
 	for key, val := range usedBytes {
-		if _, ok := availableBytes[key]; !ok {
+		vs := &VolumeStats{UsedBytes: val}
+		if ab, ok := availableBytes[key]; !ok {
 			continue
+		} else {
+			vs.AvailableBytes = ab
 		}
-		if _, ok := capacityBytes[key]; !ok {
+		if cb, ok := capacityBytes[key]; !ok {
 			continue
+		} else {
+			vs.CapacityBytes = cb
 		}
-
-		vs := VolumeStats{
-			AvailableBytes: availableBytes[key],
-			UsedBytes:      val,
-			CapacityBytes:  capacityBytes[key],
-		}
-		volumeStatsMap[key] = &vs
+		volumeStatsMap[key] = vs
 	}
 
 	return volumeStatsMap, nil

--- a/runners/pvc_autoresizer.go
+++ b/runners/pvc_autoresizer.go
@@ -249,7 +249,6 @@ func convertSizeInBytes(valStr string, capacity int64, defaultVal string) (int64
 			return 0, fmt.Errorf("annotation value should be positive: %s", valStr)
 		}
 
-		// rounding up the result to Gi
 		res := int64(float64(capacity) * rate / 100.0)
 		return res, nil
 	}

--- a/runners/pvc_autoresizer.go
+++ b/runners/pvc_autoresizer.go
@@ -190,7 +190,12 @@ func (w *pvcAutoresizer) resize(ctx context.Context, pvc *corev1.PersistentVolum
 		if err != nil {
 			return err
 		}
-		log.Info("resize started", "old capacity", curReq.Value(), "new capacity", newReq.Value())
+		log.Info("resize started",
+			"from", curReq.Value(),
+			"to", newReq.Value(),
+			"threshold", threshold,
+			"available", vs.AvailableBytes,
+		)
 		w.recorder.Eventf(pvc, corev1.EventTypeNormal, "Resized", "PVC volume is resized to %s", newReq.String())
 	}
 

--- a/runners/pvc_autoresizer_test.go
+++ b/runners/pvc_autoresizer_test.go
@@ -71,16 +71,6 @@ var _ = Describe("test resizer", func() {
 				defaultVal: "10%",
 			},
 			{
-				valStr:     "101%",
-				capacity:   100,
-				defaultVal: "10%",
-			},
-			{
-				valStr:     "11Gi",
-				capacity:   10 << 30,
-				defaultVal: "10%",
-			},
-			{
 				valStr:     "hoge",
 				capacity:   100,
 				defaultVal: "10%",
@@ -96,7 +86,7 @@ var _ = Describe("test resizer", func() {
 		It("should be error", func() {
 			for _, val := range errorCases {
 				_, err := convertSizeInBytes(val.valStr, val.capacity, val.defaultVal)
-				Expect(err).To(HaveOccurred())
+				Expect(err).To(HaveOccurred(), "%+v", val)
 			}
 		})
 	})
@@ -176,8 +166,8 @@ var _ = Describe("test resizer", func() {
 						return err
 					}
 					req := pvc.Spec.Resources.Requests.Storage().Value()
-					if req != 20<<30 {
-						return fmt.Errorf("request size should be %d, but %d", 20<<30, req)
+					if req != 11811160064 {
+						return fmt.Errorf("request size should be %d, but %d", 11811160064, req)
 					}
 					return nil
 				}, 3*time.Second).ShouldNot(HaveOccurred())

--- a/runners/suite_test.go
+++ b/runners/suite_test.go
@@ -64,9 +64,10 @@ var _ = BeforeSuite(func(done Done) {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	pvcAutoresizer := NewPVCAutoresizer(&promClient, 1*time.Second, mgr.GetEventRecorderFor("pvc-autoresizer"))
-	err = pvcAutoresizer.SetupWithManager(mgr)
+	err = SetupIndexer(mgr)
 	Expect(err).ToNot(HaveOccurred())
+
+	pvcAutoresizer := NewPVCAutoresizer(&promClient, 1*time.Second, mgr.GetEventRecorderFor("pvc-autoresizer"))
 	err = mgr.Add(pvcAutoresizer)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
This PR includes a commit to fix the calculation of `increase` size of PVC because
the intention was to derive the `increase` size from `resources.requests.storage`,
not `resources.limits.storage`.

Also, it includes several commits to cleanup and enhance logs.