### PR TITLE
Provide PVC storage limit via annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file itself is based on [Keep a CHANGELOG](https://keepachangelog.com/en/0.3.0/).
 
 ## [Unreleased]
+- Add support to providing PVC storage limit via annotation (#32)
 
 ## [0.1.4] - 2021-03-22
 ### Changed

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ allowVolumeExpansion: true
 ```
 
 To allow auto volume expansion, the PVC to be resized need to specify the upper limit of
-volume size with `.spec.resources.limits.storage`.  The PVC must have `volumeMode: Filesystem` too.
+volume size with the annotation `resize.topolvm.io/storage_limit` or the PVC spec `.spec.resources.limits.storage` (if both are present, the annotation takes precedence). The PVC must have `volumeMode: Filesystem` too.
 
 The PVC can optionally have `resize.topolvm.io/threshold` and `resize.topolvm.io/increase` annotations.
 (If they are not given, the default value is `10%`.)

--- a/runners/constants.go
+++ b/runners/constants.go
@@ -9,6 +9,9 @@ const ResizeThresholdAnnotation = "resize.topolvm.io/threshold"
 // ResizeIncreaseAnnotation is the key of amount increased.
 const ResizeIncreaseAnnotation = "resize.topolvm.io/increase"
 
+// StorageLimitAnnotation is the key of storage limit value
+const StorageLimitAnnotation = "resize.topolvm.io/storage_limit"
+
 // PreviousCapacityBytesAnnotation is the key of previous volume capacity.
 const PreviousCapacityBytesAnnotation = "resize.topolvm.io/pre_capacity_bytes"
 

--- a/runners/pvc_autoresizer_test.go
+++ b/runners/pvc_autoresizer_test.go
@@ -256,6 +256,46 @@ var _ = Describe("test resizer", func() {
 				}, 3*time.Second).ShouldNot(HaveOccurred())
 			})
 		})
+
+		It("should resize PVC with storage limit annotation", func() {
+			scName := "test-storageclass6"
+			pvcName := "test-pvc6"
+			createStorageClass(ctx, scName, provName, true)
+			createPVC(ctx, pvcNS, pvcName, scName, "50%", "20Gi", 10<<30, 0, corev1.PersistentVolumeFilesystem)
+			addStorageLimitAnnotation(ctx, pvcNS, pvcName, "100Gi")
+
+			By("60% available", func() {
+				setMetrics(pvcNS, pvcName, 6<<30, 4<<30, 10<<30)
+				Consistently(func() error {
+					var pvc corev1.PersistentVolumeClaim
+					err := k8sClient.Get(ctx, types.NamespacedName{Namespace: pvcNS, Name: pvcName}, &pvc)
+					if err != nil {
+						return err
+					}
+					req := pvc.Spec.Resources.Requests.Storage().Value()
+					if req != 10<<30 {
+						return fmt.Errorf("request size should be %d, but %d", 10<<30, req)
+					}
+					return nil
+				}, 3*time.Second).ShouldNot(HaveOccurred())
+			})
+
+			By("30% available", func() {
+				setMetrics(pvcNS, pvcName, 3<<30, 7<<30, 10<<30)
+				Eventually(func() error {
+					var pvc corev1.PersistentVolumeClaim
+					err := k8sClient.Get(ctx, types.NamespacedName{Namespace: pvcNS, Name: pvcName}, &pvc)
+					if err != nil {
+						return err
+					}
+					req := pvc.Spec.Resources.Requests.Storage().Value()
+					if req != 30<<30 {
+						return fmt.Errorf("request size should be %d, but %d", 30<<30, req)
+					}
+					return nil
+				}, 3*time.Second).ShouldNot(HaveOccurred())
+			})
+		})
 	})
 })
 
@@ -326,4 +366,20 @@ func setMetrics(ns, name string, available, used, capacity int64) {
 		UsedBytes:      used,
 		CapacityBytes:  capacity,
 	})
+}
+
+func addStorageLimitAnnotation(ctx context.Context, ns, name, storageLimit string) {
+	var pvc corev1.PersistentVolumeClaim
+	err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, &pvc)
+	Expect(err).NotTo(HaveOccurred())
+
+	// fetch currently set annotations
+	pvcAnnotations := pvc.GetAnnotations()
+
+	// add the storage limit annotation with the desired value
+	pvcAnnotations[StorageLimitAnnotation] = storageLimit
+	pvc.SetAnnotations(pvcAnnotations)
+
+	err = k8sClient.Status().Update(ctx, &pvc)
+	Expect(err).NotTo(HaveOccurred())
 }

--- a/runners/pvc_autoresizer_test.go
+++ b/runners/pvc_autoresizer_test.go
@@ -99,7 +99,7 @@ var _ = Describe("test resizer", func() {
 
 		It("should resize PVC", func() {
 			scName := "test-storageclass1"
-			pvcName := "tset-pvc1"
+			pvcName := "test-pvc1"
 			createStorageClass(ctx, scName, provName, true)
 			createPVC(ctx, pvcNS, pvcName, scName, "50%", "20Gi", 10<<30, 100<<30, corev1.PersistentVolumeFilesystem)
 
@@ -138,7 +138,7 @@ var _ = Describe("test resizer", func() {
 
 		It("should resize PVC by default settings", func() {
 			scName := "test-storageclass2"
-			pvcName := "tset-pvc2"
+			pvcName := "test-pvc2"
 			createStorageClass(ctx, scName, provName, true)
 			createPVC(ctx, pvcNS, pvcName, scName, "", "", 10<<30, 100<<30, corev1.PersistentVolumeFilesystem)
 
@@ -177,7 +177,7 @@ var _ = Describe("test resizer", func() {
 
 		It("should not resize PVC without limit", func() {
 			scName := "test-storageclass3"
-			pvcName := "tset-pvc3"
+			pvcName := "test-pvc3"
 			createStorageClass(ctx, scName, provName, true)
 			createPVC(ctx, pvcNS, pvcName, scName, "20%", "10Gi", 10<<30, 0, corev1.PersistentVolumeFilesystem)
 
@@ -200,7 +200,7 @@ var _ = Describe("test resizer", func() {
 
 		It("should not resize PVC without available StorageClass", func() {
 			scName := "test-storageclass4"
-			pvcName := "tset-pvc4"
+			pvcName := "test-pvc4"
 			createStorageClass(ctx, scName, provName, false)
 			createPVC(ctx, pvcNS, pvcName, scName, "20%", "10Gi", 10<<30, 100<<30, corev1.PersistentVolumeFilesystem)
 
@@ -236,7 +236,7 @@ var _ = Describe("test resizer", func() {
 
 		It("should not resize PVC with Block mode", func() {
 			scName := "test-storageclass5"
-			pvcName := "tset-pvc5"
+			pvcName := "test-pvc5"
 			createStorageClass(ctx, scName, provName, true)
 			createPVC(ctx, pvcNS, pvcName, scName, "20%", "10Gi", 10<<30, 100<<30, corev1.PersistentVolumeBlock)
 


### PR DESCRIPTION
fixes https://github.com/topolvm/pvc-autoresizer/issues/31

Currently `.spec.resources.requests.storage` is the only mutable field on the PVC spec, so I am not sure if relying on `.spec.resources.limits.storage` is something you want to keep or not.

I am not a fun of having multiple ways of doing the same thing, so I think using an annotation exclusively for the PVC storage limit and dropping the usage of `.spec.resources.requests.storage` is a cleaner solution. This PR does **not** tackle this point. I just wanted to get your opinion on it and understand the reasoning behind it.