### PR TITLE
don't crash on a single PVC resizing failure

### DIFF
--- a/runners/pvc_autoresizer.go
+++ b/runners/pvc_autoresizer.go
@@ -118,7 +118,7 @@ func (w *pvcAutoresizer) reconcile(ctx context.Context) error {
 			}
 			err = w.resize(ctx, &pvc, vsMap[namespacedName])
 			if err != nil {
-				return err
+				w.log.WithValues("namespace", pvc.Namespace, "name", pvc.Name).Error(err, "failed to resize PVC")
 			}
 		}
 	}


### PR DESCRIPTION
The controller shouldn't crash if a single PVC resize failure happens.

I run the controller with the flag `--no-annotation-check`, so it might be the case that someone sets the controller annotations on a PVC that is not resizable (StorageClass does not allow volume expansion). Right now this leads to stopping the processing for all PVCs.

I think it is safe to fail that single PVC and keep processing the others. Until we have metrics, relying on logged errors should be enough. WDYT ?