### PR TITLE
helm: enable to specify nodeSelector

### DIFF
--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -34,6 +34,7 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | controller.args.additionalArgs | list | `[]` | Specify additional args. |
 | controller.args.interval | string | `"10s"` | Specify interval to monitor pvc capacity. Used as "--interval" option |
 | controller.args.prometheusURL | string | `"http://prometheus-prometheus-oper-prometheus.prometheus.svc:9090"` | Specify Prometheus URL to query volume stats. Used as "--prometheus-url" option |
+| controller.nodeSelector | object | `{}` | Specify nodeSelector. |
 | controller.replicas | int | `1` | Specify the number of replicas of the controller Pod. |
 | controller.resources | object | `{"requests":{"cpu":"100m","memory":"20Mi"}}` | Specify resources. |
 | controller.terminationGracePeriodSeconds | string | `nil` | Specify terminationGracePeriodSeconds. |

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app.kubernetes.io/name: pvc-autoresizer
     spec:
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "pvc-autoresizer.fullname" . }}-controller
       {{- with .Values.controller.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -31,5 +31,8 @@ controller:
       cpu: 100m
       memory: 20Mi
 
+  # controller.nodeSelector -- Specify nodeSelector.
+  nodeSelector: {}
+
   # controller.terminationGracePeriodSeconds -- Specify terminationGracePeriodSeconds.
   terminationGracePeriodSeconds:  # 10


### PR DESCRIPTION
# why

To enable to deploy to dedicated node

# what

- Enable to specify `nodeSelector` in the helm chart