### PR TITLE
output error when storage_limit annotation is invalid

### DIFF
--- a/runners/pvc_autoresizer.go
+++ b/runners/pvc_autoresizer.go
@@ -72,7 +72,7 @@ func (w *pvcAutoresizer) Start(ctx context.Context) error {
 func isTargetPVC(pvc *corev1.PersistentVolumeClaim) (bool, error) {
 	quantity, err := pvcStorageLimit(pvc)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("invalid storage limit: %w", err)
 	}
 	if quantity.IsZero() {
 		return false, nil


### PR DESCRIPTION
pvcStorageLimit and isTargetPVC returns error when
storage_limit annotation is invalid. output error
log and increment metrics when the previous situation.

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>