### PR TITLE
Extend metrics to include pvc name

### DIFF
--- a/metrics/resizer.go
+++ b/metrics/resizer.go
@@ -22,7 +22,7 @@ type resizerSuccessResizeTotalAdapter struct {
 }
 
 func (a *resizerSuccessResizeTotalAdapter) Increment(pvcname string, pvcns string) {
-	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname, "persistentvolumeclaimnamespace": pvcns}).Inc()
+	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname, "namespace": pvcns}).Inc()
 }
 
 type resizerFailedResizeTotalAdapter struct {
@@ -30,7 +30,7 @@ type resizerFailedResizeTotalAdapter struct {
 }
 
 func (a *resizerFailedResizeTotalAdapter) Increment(pvcname string, pvcns string) {
-	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname, "persistentvolumeclaimnamespace": pvcns}).Inc()
+	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname, "namespace": pvcns}).Inc()
 }
 
 type resizerLoopSecondsTotalAdapter struct {
@@ -46,7 +46,7 @@ type resizerLimitReachedTotalAdapter struct {
 }
 
 func (a *resizerLimitReachedTotalAdapter) Increment(pvcname string, pvcns string) {
-	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname, "persistentvolumeclaimnamespace": pvcns}).Inc()
+	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname, "namespace": pvcns}).Inc()
 }
 
 var (
@@ -54,13 +54,13 @@ var (
 		Namespace: MetricsNamespace,
 		Name:      ResizerSuccessResizeTotalKey,
 		Help:      "counter that indicates how many volume expansion processing resized succeed.",
-	}, []string{"persistentvolumeclaim", "persistentvolumeclaimnamespace"})
+	}, []string{"persistentvolumeclaim", "namespace"})
 
 	resizerFailedResizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      ResizerFailedResizeTotalKey,
 		Help:      "counter that indicates how many volume expansion processing resizes fail.",
-	}, []string{"persistentvolumeclaim", "persistentvolumeclaimnamespace"})
+	}, []string{"persistentvolumeclaim", "namespace"})
 
 	resizerLoopSecondsTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
@@ -72,7 +72,7 @@ var (
 		Namespace: MetricsNamespace,
 		Name:      ResizerLimitReachedTotalKey,
 		Help:      "counter that indicates how many storage limits were reached.",
-	}, []string{"persistentvolumeclaim", "persistentvolumeclaimnamespace"})
+	}, []string{"persistentvolumeclaim", "namespace"})
 
 	ResizerSuccessResizeTotal *resizerSuccessResizeTotalAdapter = &resizerSuccessResizeTotalAdapter{metric: *resizerSuccessResizeTotal}
 	ResizerFailedResizeTotal  *resizerFailedResizeTotalAdapter  = &resizerFailedResizeTotalAdapter{metric: *resizerFailedResizeTotal}

--- a/metrics/resizer.go
+++ b/metrics/resizer.go
@@ -18,19 +18,19 @@ func init() {
 }
 
 type resizerSuccessResizeTotalAdapter struct {
-	metric prometheus.Counter
+	metric prometheus.CounterVec
 }
 
-func (a *resizerSuccessResizeTotalAdapter) Increment() {
-	a.metric.Inc()
+func (a *resizerSuccessResizeTotalAdapter) Increment(pvcname string) {
+	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname}).Inc()
 }
 
 type resizerFailedResizeTotalAdapter struct {
-	metric prometheus.Counter
+	metric prometheus.CounterVec
 }
 
-func (a *resizerFailedResizeTotalAdapter) Increment() {
-	a.metric.Inc()
+func (a *resizerFailedResizeTotalAdapter) Increment(pvcname string) {
+	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname}).Inc()
 }
 
 type resizerLoopSecondsTotalAdapter struct {
@@ -42,25 +42,25 @@ func (a *resizerLoopSecondsTotalAdapter) Add(value float64) {
 }
 
 type resizerLimitReachedTotalAdapter struct {
-	metric prometheus.Counter
+	metric prometheus.CounterVec
 }
 
-func (a *resizerLimitReachedTotalAdapter) Increment() {
-	a.metric.Inc()
+func (a *resizerLimitReachedTotalAdapter) Increment(pvcname string) {
+	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname}).Inc()
 }
 
 var (
-	resizerSuccessResizeTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	resizerSuccessResizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      ResizerSuccessResizeTotalKey,
-		Help:      "counter that indicates how many volume expansion processing resizes succeed.",
-	})
+		Help:      "counter that indicates how m any volume expansion processing resized succeed.",
+	}, []string{"persistentvolumeclaim"})
 
-	resizerFailedResizeTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	resizerFailedResizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      ResizerFailedResizeTotalKey,
 		Help:      "counter that indicates how many volume expansion processing resizes fail.",
-	})
+	}, []string{"persistentvolumeclaim"})
 
 	resizerLoopSecondsTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
@@ -68,16 +68,16 @@ var (
 		Help:      "counter that indicates the sum of seconds spent on volume expansion processing loops.",
 	})
 
-	resizerLimitReachedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+	resizerLimitReachedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      ResizerLimitReachedTotalKey,
-		Help:      "counter that indicates how many storage limit was reached.",
-	})
+		Help:      "counter that indicates how many storage limits were reached.",
+	}, []string{"persistentvolumeclaim"})
 
-	ResizerSuccessResizeTotal *resizerSuccessResizeTotalAdapter = &resizerSuccessResizeTotalAdapter{metric: resizerSuccessResizeTotal}
-	ResizerFailedResizeTotal  *resizerFailedResizeTotalAdapter  = &resizerFailedResizeTotalAdapter{metric: resizerFailedResizeTotal}
+	ResizerSuccessResizeTotal *resizerSuccessResizeTotalAdapter = &resizerSuccessResizeTotalAdapter{metric: *resizerSuccessResizeTotal}
+	ResizerFailedResizeTotal  *resizerFailedResizeTotalAdapter  = &resizerFailedResizeTotalAdapter{metric: *resizerFailedResizeTotal}
 	ResizerLoopSecondsTotal   *resizerLoopSecondsTotalAdapter   = &resizerLoopSecondsTotalAdapter{metric: resizerLoopSecondsTotal}
-	ResizerLimitReachedTotal  *resizerLimitReachedTotalAdapter  = &resizerLimitReachedTotalAdapter{metric: resizerLimitReachedTotal}
+	ResizerLimitReachedTotal  *resizerLimitReachedTotalAdapter  = &resizerLimitReachedTotalAdapter{metric: *resizerLimitReachedTotal}
 )
 
 func registerResizerMetrics() {

--- a/metrics/resizer.go
+++ b/metrics/resizer.go
@@ -21,16 +21,16 @@ type resizerSuccessResizeTotalAdapter struct {
 	metric prometheus.CounterVec
 }
 
-func (a *resizerSuccessResizeTotalAdapter) Increment(pvcname string) {
-	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname}).Inc()
+func (a *resizerSuccessResizeTotalAdapter) Increment(pvcname string, pvcns string) {
+	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname, "persistentvolumeclaimnamespace": pvcns}).Inc()
 }
 
 type resizerFailedResizeTotalAdapter struct {
 	metric prometheus.CounterVec
 }
 
-func (a *resizerFailedResizeTotalAdapter) Increment(pvcname string) {
-	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname}).Inc()
+func (a *resizerFailedResizeTotalAdapter) Increment(pvcname string, pvcns string) {
+	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname, "persistentvolumeclaimnamespace": pvcns}).Inc()
 }
 
 type resizerLoopSecondsTotalAdapter struct {
@@ -45,22 +45,22 @@ type resizerLimitReachedTotalAdapter struct {
 	metric prometheus.CounterVec
 }
 
-func (a *resizerLimitReachedTotalAdapter) Increment(pvcname string) {
-	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname}).Inc()
+func (a *resizerLimitReachedTotalAdapter) Increment(pvcname string, pvcns string) {
+	a.metric.With(prometheus.Labels{"persistentvolumeclaim": pvcname, "persistentvolumeclaimnamespace": pvcns}).Inc()
 }
 
 var (
 	resizerSuccessResizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      ResizerSuccessResizeTotalKey,
-		Help:      "counter that indicates how m any volume expansion processing resized succeed.",
-	}, []string{"persistentvolumeclaim"})
+		Help:      "counter that indicates how many volume expansion processing resized succeed.",
+	}, []string{"persistentvolumeclaim", "persistentvolumeclaimnamespace"})
 
 	resizerFailedResizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      ResizerFailedResizeTotalKey,
 		Help:      "counter that indicates how many volume expansion processing resizes fail.",
-	}, []string{"persistentvolumeclaim"})
+	}, []string{"persistentvolumeclaim", "persistentvolumeclaimnamespace"})
 
 	resizerLoopSecondsTotal = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
@@ -72,7 +72,7 @@ var (
 		Namespace: MetricsNamespace,
 		Name:      ResizerLimitReachedTotalKey,
 		Help:      "counter that indicates how many storage limits were reached.",
-	}, []string{"persistentvolumeclaim"})
+	}, []string{"persistentvolumeclaim", "persistentvolumeclaimnamespace"})
 
 	ResizerSuccessResizeTotal *resizerSuccessResizeTotalAdapter = &resizerSuccessResizeTotalAdapter{metric: *resizerSuccessResizeTotal}
 	ResizerFailedResizeTotal  *resizerFailedResizeTotalAdapter  = &resizerFailedResizeTotalAdapter{metric: *resizerFailedResizeTotal}

--- a/metrics/resizer_test.go
+++ b/metrics/resizer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestResizerSuccessResizeTotal(t *testing.T) {
-	ResizerSuccessResizeTotal.Increment()
+	ResizerSuccessResizeTotal.Increment("my-test-pvc")
 	actual := testutil.ToFloat64(resizerSuccessResizeTotal)
 	if actual != float64(1) {
 		t.Fatalf("value is not %d", 1)
@@ -16,7 +16,7 @@ func TestResizerSuccessResizeTotal(t *testing.T) {
 }
 
 func TestResizerFailedResizeTotal(t *testing.T) {
-	ResizerFailedResizeTotal.Increment()
+	ResizerFailedResizeTotal.Increment("my-test-pvc")
 	actual := testutil.ToFloat64(resizerFailedResizeTotal)
 	if actual != float64(1) {
 		t.Fatalf("value is not %d", 1)
@@ -35,7 +35,7 @@ func TestResizerLoopSecondsTotal(t *testing.T) {
 }
 
 func TestResizerLimitReachedTotal(t *testing.T) {
-	ResizerLimitReachedTotal.Increment()
+	ResizerLimitReachedTotal.Increment("my-test-pvc")
 	actual := testutil.ToFloat64(resizerLimitReachedTotal)
 	if actual != float64(1) {
 		t.Fatalf("value is not %d", 1)

--- a/metrics/resizer_test.go
+++ b/metrics/resizer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestResizerSuccessResizeTotal(t *testing.T) {
-	ResizerSuccessResizeTotal.Increment("my-test-pvc")
+	ResizerSuccessResizeTotal.Increment("my-test-pvc", "my-test-namespace")
 	actual := testutil.ToFloat64(resizerSuccessResizeTotal)
 	if actual != float64(1) {
 		t.Fatalf("value is not %d", 1)
@@ -16,7 +16,7 @@ func TestResizerSuccessResizeTotal(t *testing.T) {
 }
 
 func TestResizerFailedResizeTotal(t *testing.T) {
-	ResizerFailedResizeTotal.Increment("my-test-pvc")
+	ResizerFailedResizeTotal.Increment("my-test-pvc", "my-test-namespace")
 	actual := testutil.ToFloat64(resizerFailedResizeTotal)
 	if actual != float64(1) {
 		t.Fatalf("value is not %d", 1)
@@ -35,7 +35,7 @@ func TestResizerLoopSecondsTotal(t *testing.T) {
 }
 
 func TestResizerLimitReachedTotal(t *testing.T) {
-	ResizerLimitReachedTotal.Increment("my-test-pvc")
+	ResizerLimitReachedTotal.Increment("my-test-pvc", "my-test-namespace")
 	actual := testutil.ToFloat64(resizerLimitReachedTotal)
 	if actual != float64(1) {
 		t.Fatalf("value is not %d", 1)

--- a/runners/pvc_autoresizer.go
+++ b/runners/pvc_autoresizer.go
@@ -120,7 +120,7 @@ func (w *pvcAutoresizer) reconcile(ctx context.Context) error {
 		for _, pvc := range pvcs.Items {
 			isTarget, err := isTargetPVC(&pvc)
 			if err != nil {
-				metrics.ResizerFailedResizeTotal.Increment(pvc.Name)
+				metrics.ResizerFailedResizeTotal.Increment(pvc.Name, pvc.Namespace)
 				w.log.WithValues("namespace", pvc.Namespace, "name", pvc.Name).Error(err, "failed to check target PVC")
 				continue
 			} else if !isTarget {
@@ -135,7 +135,7 @@ func (w *pvcAutoresizer) reconcile(ctx context.Context) error {
 			}
 			err = w.resize(ctx, &pvc, vsMap[namespacedName])
 			if err != nil {
-				metrics.ResizerFailedResizeTotal.Increment(pvc.Name)
+				metrics.ResizerFailedResizeTotal.Increment(pvc.Name, pvc.Namespace)
 				w.log.WithValues("namespace", pvc.Namespace, "name", pvc.Name).Error(err, "failed to resize PVC")
 			}
 		}
@@ -189,7 +189,7 @@ func (w *pvcAutoresizer) resize(ctx context.Context, pvc *corev1.PersistentVolum
 	}
 	if curReq.Cmp(limitRes) == 0 {
 		log.Info("volume storage limit reached")
-		metrics.ResizerLimitReachedTotal.Increment(pvc.Name)
+		metrics.ResizerLimitReachedTotal.Increment(pvc.Name, pvc.Namespace)
 		return nil
 	}
 
@@ -219,7 +219,7 @@ func (w *pvcAutoresizer) resize(ctx context.Context, pvc *corev1.PersistentVolum
 			"inodesAvailable", vs.AvailableInodeSize,
 		)
 		w.recorder.Eventf(pvc, corev1.EventTypeNormal, "Resized", "PVC volume is resized to %s", newReq.String())
-		metrics.ResizerSuccessResizeTotal.Increment(pvc.Name)
+		metrics.ResizerSuccessResizeTotal.Increment(pvc.Name, pvc.Namespace)
 	}
 
 	return nil


### PR DESCRIPTION
Adds PersistentVolumeClaim name to appropriate metrics. Before adding too many additional labels, wanted to get feedback on if this was an appropriate approach.

resolves #90 