### PR TITLE
Update example to use preferred storage_limit annotation

### DIFF
--- a/example/podpvc.yaml
+++ b/example/podpvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 metadata:
   name: resizable-pvc
   annotations:
+    resize.topolvm.io/storage_limit: 10Gi
     resize.topolvm.io/threshold: 20%
     resize.topolvm.io/increase: 2Gi
 spec:
@@ -11,8 +12,6 @@ spec:
   resources:
     requests:
       storage: 1Gi
-    limits:
-      storage: 10Gi
   storageClassName: topolvm-provisioner
 ---
 apiVersion: v1


### PR DESCRIPTION
Updates example to use preferred `storage_limit` annotation instead of `.spec.resources.limits.storage`