### PR TITLE
fix clean target of e2e/Makefile

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -92,6 +92,12 @@ kube-prometheus:
 
 .PHONY: clean
 clean: stop-lvmd
+	for f in $$($(SUDO) find $(TMPDIR) -type f); do \
+		if $(SUDO) mountpoint -q $$f; then \
+			$(SUDO) umount $$f; \
+		fi; \
+	done
+	$(SUDO) rm -rf $(TMPDIR)/controller $(TMPDIR)/worker
 	rm -rf \
 		$(TMPDIR) \
 		autoresizer.img \


### PR DESCRIPTION
`make -C e2e clean` fails with the following error:

```
rm: cannot remove '/tmp/autoresizer/controller/pods': Permission denied
rm: cannot remove '/tmp/autoresizer/worker/pods': Permission denied
make: *** [Makefile:95: clean] Error 1
```

Even if executing with sudo, we get something like:

```
rm: cannot remove '/tmp/autoresizer/worker/pods/78b7ad42-aeb2-48b3-8c01-ef37cba63a00/volume-subpaths/web-config/prometheus/4': Device or resource busy
rm: cannot remove '/tmp/autoresizer/worker/pods/c4169fcb-6297-4053-9faa-9ae965962f3b/volume-subpaths/web-config/prometheus/4': Device or resource busy
make: *** [Makefile:95: clean] Error 1
```

These files are mount points. To teardown properly, unmount these before removing TMPDIR.