### PR TITLE
Modify to using a pvc capacity for calculate new storage request

### DIFF
--- a/runners/pvc_autoresizer.go
+++ b/runners/pvc_autoresizer.go
@@ -198,7 +198,7 @@ func (w *pvcAutoresizer) resize(ctx context.Context, pvc *corev1.PersistentVolum
 		log.Error(err, "fetching storage limit failed")
 		return err
 	}
-	if cap.Cmp(limitRes) == 0 || cap.Cmp(limitRes) == 1 {
+	if cap.Cmp(limitRes) >= 0 {
 		log.Info("volume storage limit reached")
 		metrics.ResizerLimitReachedTotal.Increment(pvc.Name, pvc.Namespace)
 		return nil

--- a/runners/pvc_autoresizer.go
+++ b/runners/pvc_autoresizer.go
@@ -164,19 +164,16 @@ func (w *pvcAutoresizer) resize(ctx context.Context, pvc *corev1.PersistentVolum
 	cap, exists := pvc.Status.Capacity[corev1.ResourceStorage]
 	if !exists {
 		log.Info("skip resizing because pvc capacity is not set yet")
-		// lint:ignore nilerr ignores this because invalid annotations should be allowed.
 		return nil
 	}
 	if cap.Value() == 0 {
 		log.Info("skip resizing because pvc capacity size is zero")
-		// lint:ignore nilerr ignores this because invalid annotations should be allowed.
 		return nil
 	}
 
 	increase, err := convertSizeInBytes(pvc.Annotations[ResizeIncreaseAnnotation], cap.Value(), DefaultIncrease)
 	if err != nil {
 		log.V(logLevelWarn).Info("failed to convert increase annotation", "error", err.Error())
-		// lint:ignore nilerr ignores this because invalid annotations should be allowed.
 		return nil
 	}
 

--- a/runners/pvc_autoresizer.go
+++ b/runners/pvc_autoresizer.go
@@ -161,8 +161,19 @@ func (w *pvcAutoresizer) resize(ctx context.Context, pvc *corev1.PersistentVolum
 		return nil
 	}
 
-	curReq := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
-	increase, err := convertSizeInBytes(pvc.Annotations[ResizeIncreaseAnnotation], curReq.Value(), DefaultIncrease)
+	cap, exists := pvc.Status.Capacity[corev1.ResourceStorage]
+	if !exists {
+		log.Info("skip resizing because pvc capacity is not set yet")
+		// lint:ignore nilerr ignores this because invalid annotations should be allowed.
+		return nil
+	}
+	if cap.Value() == 0 {
+		log.Info("skip resizing because pvc capacity size is zero")
+		// lint:ignore nilerr ignores this because invalid annotations should be allowed.
+		return nil
+	}
+
+	increase, err := convertSizeInBytes(pvc.Annotations[ResizeIncreaseAnnotation], cap.Value(), DefaultIncrease)
 	if err != nil {
 		log.V(logLevelWarn).Info("failed to convert increase annotation", "error", err.Error())
 		// lint:ignore nilerr ignores this because invalid annotations should be allowed.
@@ -187,7 +198,7 @@ func (w *pvcAutoresizer) resize(ctx context.Context, pvc *corev1.PersistentVolum
 		log.Error(err, "fetching storage limit failed")
 		return err
 	}
-	if curReq.Cmp(limitRes) == 0 {
+	if cap.Cmp(limitRes) == 0 || cap.Cmp(limitRes) == 1 {
 		log.Info("volume storage limit reached")
 		metrics.ResizerLimitReachedTotal.Increment(pvc.Name, pvc.Namespace)
 		return nil
@@ -197,7 +208,7 @@ func (w *pvcAutoresizer) resize(ctx context.Context, pvc *corev1.PersistentVolum
 		if pvc.Annotations == nil {
 			pvc.Annotations = make(map[string]string)
 		}
-		newReqBytes := int64(math.Ceil(float64(curReq.Value()+increase)/(1<<30))) << 30
+		newReqBytes := int64(math.Ceil(float64(cap.Value()+increase)/(1<<30))) << 30
 		newReq := resource.NewQuantity(newReqBytes, resource.BinarySI)
 		if newReq.Cmp(limitRes) > 0 {
 			newReq = &limitRes
@@ -211,7 +222,7 @@ func (w *pvcAutoresizer) resize(ctx context.Context, pvc *corev1.PersistentVolum
 			return err
 		}
 		log.Info("resize started",
-			"from", curReq.Value(),
+			"from", cap.Value(),
 			"to", newReq.Value(),
 			"threshold", threshold,
 			"available", vs.AvailableBytes,

--- a/runners/pvc_autoresizer_test.go
+++ b/runners/pvc_autoresizer_test.go
@@ -432,6 +432,9 @@ func createPVC(ctx context.Context, ns, name, scName, threshold, inodesThreshold
 	Expect(err).NotTo(HaveOccurred())
 
 	pvc.Status.Phase = corev1.ClaimBound
+	pvc.Status.Capacity = map[corev1.ResourceName]resource.Quantity{
+		corev1.ResourceStorage: *resource.NewQuantity(request, resource.BinarySI),
+	}
 	err = k8sClient.Status().Update(ctx, &pvc)
 	Expect(err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
#77

I modified to using a pvc capacity size to calculate the new storage request size.
This change requires pvc.status.capacity to be set, but for the major CSI drivers are set pvc.status.capacity to some value, so I don't think it's a problem.

### NOTE

- pvc.status.capacity is set the same value to linked pv.spec.capacity and the PVC is stored async: https://github.com/kubernetes/kubernetes/blob/v1.23.5/pkg/controller/volume/persistentvolume/pv_controller.go#L809
- pv.spec.capacity is set the CreateVolumeResponse.volume.capacity value if the pv was created by a CSI Driver: https://github.com/kubernetes-csi/external-provisioner/blob/v3.1.0/pkg/controller/controller.go#L744-L833
- above pv is saved by the sig-storage-lib-external-provisioner controller: https://github.com/kubernetes-csi/external-provisioner/blob/v3.1.0/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/v8/controller/volume_store.go#L155
- GetCapacityBytes method return 0 if the res.volume is nil https://github.com/kubernetes-csi/external-provisioner/blob/v3.1.0/vendor/github.com/container-storage-interface/spec/lib/go/csi/csi.pb.go#L1555

#### CreateResponse Implementations

- topolvm - use requestGiB: https://github.com/topolvm/topolvm/blob/v0.10.6/driver/controller.go#L142
- hcloud - use Volume API response: https://github.com/hetznercloud/csi-driver/blob/v1.6.0/driver/controller.go#L65-L93
- AWS EBS - use Volume API response: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/v1.5.1/pkg/driver/controller.go#L732
- Azure Disk - use requestGiB:https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/v1.13.0/pkg/azuredisk/controllerserver.go#L257
- GCE PB - use Volume API response: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/v1.4.0/pkg/gce-pd-csi-driver/controller.go#L1223-L1226
