### PR TITLE
revise CODEOWNERS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # @cupnes: Yuma Ohgami
 # @daichimukai: Daichi Mukai
 # @peng225: Shinya Hayashi
-* @toshipp @llamerada-jp @satoru-takeuchi @cupnes @daichimukai @peng225
+* @topolvm/reviewers


### PR DESCRIPTION
Github assigns codeowers as reviewers to PR automatically and the assignment can not be changed.
To avoid that, use a team instead.