### PR TITLE
Add support for namespace allow list

### DIFF
--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -33,6 +33,7 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 |-----|------|---------|-------------|
 | controller.args.additionalArgs | list | `[]` | Specify additional args. |
 | controller.args.interval | string | `"10s"` | Specify interval to monitor pvc capacity. Used as "--interval" option |
+| controller.args.namespaces | list | `[]` | Specify namespaces to control the pvcs of. Empty for all namespaces. Used as "--namespaces" option |
 | controller.args.prometheusURL | string | `"http://prometheus-prometheus-oper-prometheus.prometheus.svc:9090"` | Specify Prometheus URL to query volume stats. Used as "--prometheus-url" option |
 | controller.nodeSelector | object | `{}` | Map of key-value pairs for scheduling pods on specific nodes. |
 | controller.replicas | int | `1` | Specify the number of replicas of the controller Pod. |

--- a/charts/pvc-autoresizer/templates/controller/clusterrole.yaml
+++ b/charts/pvc-autoresizer/templates/controller/clusterrole.yaml
@@ -1,6 +1,22 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: {{ template "pvc-autoresizer.fullname" . }}-controller-storageclasses
+  labels:
+    {{- include "pvc-autoresizer.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: {{ template "pvc-autoresizer.fullname" . }}-controller
   labels:
     {{- include "pvc-autoresizer.labels" . | nindent 4 }}
@@ -21,14 +37,6 @@ rules:
   verbs:
   - get
   - list
+  - watch
   - patch
   - update
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch

--- a/charts/pvc-autoresizer/templates/controller/clusterrolebinding.yaml
+++ b/charts/pvc-autoresizer/templates/controller/clusterrolebinding.yaml
@@ -1,6 +1,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: {{ template "pvc-autoresizer.fullname" . }}-controller-storageclasses
+  labels:
+    {{- include "pvc-autoresizer.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "pvc-autoresizer.fullname" . }}-controller-storageclasses
+subjects:
+- kind: ServiceAccount
+  name: {{ template "pvc-autoresizer.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
+
+{{- if not .Values.controller.args.namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: {{ template "pvc-autoresizer.fullname" . }}-controller
   labels:
     {{- include "pvc-autoresizer.labels" . | nindent 4 }}
@@ -12,3 +29,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "pvc-autoresizer.fullname" . }}-controller
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -26,6 +26,9 @@ spec:
           args:
             - --prometheus-url={{ .Values.controller.args.prometheusURL }}
             - --interval={{ .Values.controller.args.interval }}
+          {{- if .Values.controller.args.namespaces }}
+            - --namespaces={{ join "," .Values.controller.args.namespaces }}
+          {{- end }}
           {{- with .Values.controller.args.additionalArgs -}}
             {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/pvc-autoresizer/templates/controller/role.yaml
+++ b/charts/pvc-autoresizer/templates/controller/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "pvc-autoresizer.fullname" . }}-leader-election-role
+  name: {{ template "pvc-autoresizer.fullname" . }}-leader-election
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pvc-autoresizer.labels" . | nindent 4 }}

--- a/charts/pvc-autoresizer/templates/controller/rolebinding.yaml
+++ b/charts/pvc-autoresizer/templates/controller/rolebinding.yaml
@@ -1,15 +1,34 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "pvc-autoresizer.fullname" . }}-leader-election-rolebinding
+  name: {{ template "pvc-autoresizer.fullname" . }}-leader-election
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pvc-autoresizer.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "pvc-autoresizer.fullname" . }}-leader-election-role
+  name: {{ template "pvc-autoresizer.fullname" . }}-leader-election
 subjects:
 - kind: ServiceAccount
   name: {{ template "pvc-autoresizer.fullname" . }}-controller
   namespace: {{ .Release.Namespace }}
+
+{{- range .Values.controller.args.namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "pvc-autoresizer.fullname" $ }}-controller
+  namespace: {{ . }}
+  labels:
+    {{- include "pvc-autoresizer.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "pvc-autoresizer.fullname" $ }}-controller
+subjects:
+- kind: ServiceAccount
+  name: {{ template "pvc-autoresizer.fullname" $ }}-controller
+  namespace: {{ $.Release.Namespace }}
+{{- end }}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -18,6 +18,10 @@ controller:
     # Used as "--prometheus-url" option
     prometheusURL: http://prometheus-prometheus-oper-prometheus.prometheus.svc:9090
 
+    # controller.args.namespaces -- Specify namespaces to control the pvcs of. Empty for all namespaces.
+    # Used as "--namespaces" option
+    namespaces: []
+
     # controller.args.interval -- Specify interval to monitor pvc capacity.
     # Used as "--interval" option
     interval: 10s

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 var config struct {
 	metricsAddr    string
 	healthAddr     string
+	namespaces     []string
 	watchInterval  time.Duration
 	prometheusURL  string
 	skipAnnotation bool
@@ -41,6 +42,7 @@ func init() {
 	fs := rootCmd.Flags()
 	fs.StringVar(&config.metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	fs.StringVar(&config.healthAddr, "health-addr", ":8081", "The address of health/readiness probes.")
+	fs.StringSliceVar(&config.namespaces, "namespaces", []string{}, "Namespaces to resize PersistentVolumeClaims within. Empty for all namespaces.")
 	fs.DurationVar(&config.watchInterval, "interval", 1*time.Minute, "Interval to monitor pvc capacity.")
 	fs.StringVar(&config.prometheusURL, "prometheus-url", "", "Prometheus URL to query volume stats.")
 	fs.BoolVar(&config.skipAnnotation, "no-annotation-check", false, "Skip annotation check for StorageClass")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
@@ -28,11 +29,17 @@ func init() {
 func subMain() error {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(config.development)))
 
+	var cacheFunc cache.NewCacheFunc
+	if len(config.namespaces) > 0 {
+		cacheFunc = cache.MultiNamespacedCacheBuilder(config.namespaces)
+	}
+
 	graceTimeout := 10 * time.Second
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  scheme,
 		Port:                    9443,
 		MetricsBindAddress:      config.metricsAddr,
+		NewCache:                cacheFunc,
 		HealthProbeBindAddress:  config.healthAddr,
 		LeaderElection:          true,
 		LeaderElectionID:        "49e22f61.topolvm.io",


### PR DESCRIPTION
Hi, I am a fan on this project. I was hoping to contribute a change that would
add support for watching a small number of namespaces to better enable
deployment of this project in environments where broad permissions are heavily
scrutinized.

I didn't see much guidance with regards to contributions. Please let me know how
you feel about this type of change or any improvements I could make. The extent of
my testing was building this image and deploying it via the helm chart to a test kubernetes
cluster where it appears to behave as expected. I would appreciate any additional
testing guidance that could be provided.

# Change Details

* Adds support for namespace allow list. This is useful when running the
  controller in clusters where cluster-scoped edit permissions are of
  concern.
  * Add controller argument 'namespaces' that is list of namespaces.
  * If 'namespaces' argument is set, use a multi-namespaced cache
    instead of default global cache.
  * Add chart value for specifying namespaces.
  * Split cluster role into separate cluster roles.
    * Cluster role pertaining to storage classes.
    * Cluster role pertaining to persistent volume claims and events.
  * Change cluster role binding creation.
    * If 'namespaces' list is non-empty, create a separate role binding
      in each namespace to the persistent volume claims and events
      cluster role.
    * If 'namespaces' list is empty, create a cluster role binding to
      the persistent volume claims and events cluster role.
* Remove '-role' and '-rolebinding' suffixes from leader election role.
  * Including in the name is redundant with their kind.