### PR TITLE
Fix failing project-bot workflow triggered by dependabot.

### DIFF
--- a/.github/workflows/project-bot.yaml
+++ b/.github/workflows/project-bot.yaml
@@ -3,7 +3,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 jobs:


### PR DESCRIPTION
Due to the github change, worflows triggered by dependabot can not read
secrets. see
https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
To fix this, we use pull_request_target instead.