### PR TITLE
github/workflows: Use output parameter instead of set-output command

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -39,14 +39,6 @@ jobs:
       - name: "Set up chart-testing"
         uses: helm/chart-testing-action@v2.3.1
 
-      - name: "Run chart-testing (list-changed)"
-        id: "list-changed"
-        run: |
-          changed=$(ct list-changed --config ct.yaml)
-          if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
-          fi
-
       - name: "Run chart-testing (lint)"
         run: ct lint --config ct.yaml
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,8 +17,8 @@ jobs:
             exit 1
           fi
           if [ $(echo $VERSION | grep "-") ]; then PRERELEASE=true; else PRERELEASE=false; fi
-          echo "::set-output name=version::${VERSION}"
-          echo "::set-output name=prerelease::${PRERELEASE}"
+          echo "version=${VERSION}" >> ${GITHUB_OUTPUT}
+          echo "prerelease=${PRERELEASE}" >> ${GITHUB_OUTPUT}
       - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3


### PR DESCRIPTION
GitHub has announced that set-output and save-state will be discontinued.
We need to move to setting output parameters without these mechanisms.
Also, unnecessary steps have been removed.