### PR TITLE
Helm chart | Added controller.podAnnotations to helm chart

### DIFF
--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -36,6 +36,7 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | controller.args.namespaces | list | `[]` | Specify namespaces to control the pvcs of. Empty for all namespaces. Used as "--namespaces" option |
 | controller.args.prometheusURL | string | `"http://prometheus-prometheus-oper-prometheus.prometheus.svc:9090"` | Specify Prometheus URL to query volume stats. Used as "--prometheus-url" option |
 | controller.nodeSelector | object | `{}` | Map of key-value pairs for scheduling pods on specific nodes. |
+| controller.podAnnotations | object | `{}` | Annotations to be added to controller pods. |
 | controller.replicas | int | `1` | Specify the number of replicas of the controller Pod. |
 | controller.resources | object | `{"requests":{"cpu":"100m","memory":"20Mi"}}` | Specify resources. |
 | controller.terminationGracePeriodSeconds | string | `nil` | Specify terminationGracePeriodSeconds. |

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: pvc-autoresizer
-      {{ if .Values.controller.podAnnotations -}}
+      {{- if .Values.controller.podAnnotations}}
       annotations:
         {{- toYaml .Values.controller.podAnnotations | nindent 8 }}
       {{ end -}}

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -14,6 +14,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: pvc-autoresizer
+      {{ if .Values.controller.podAnnotations -}}
+      annotations:
+        {{- toYaml .Values.controller.podAnnotations | nindent 8 }}
+      {{ end -}}
     spec:
       serviceAccountName: {{ template "pvc-autoresizer.fullname" . }}-controller
       {{- with .Values.controller.terminationGracePeriodSeconds }}

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       {{- if .Values.controller.podAnnotations}}
       annotations:
         {{- toYaml .Values.controller.podAnnotations | nindent 8 }}
-      {{ end -}}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "pvc-autoresizer.fullname" . }}-controller
       {{- with .Values.controller.terminationGracePeriodSeconds }}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -35,6 +35,9 @@ controller:
       cpu: 100m
       memory: 20Mi
 
+  # controller.podAnnotations -- Annotations to be added to controller pods.
+  podAnnotations: {}
+
   # controller.terminationGracePeriodSeconds -- Specify terminationGracePeriodSeconds.
   terminationGracePeriodSeconds:  # 10
 


### PR DESCRIPTION
Added the option to customize controller's podTemplate annotations using a new value `controller.podAnnotations`.

Rationale to introduce this change is being able to configure annotations for Prometheus Kubernetes service discovery, for cases when Prometheus Operator is not being used.