### PR TITLE
update go 1.19 to fix ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage1: Build the pvc-autoresizer binary
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/topolvm/pvc-autoresizer
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.3


### PR DESCRIPTION
By the error message below, go 1.19 looks to be required by some packages. And k8s 1.23, ~ 1.25 use go 1.19. So I try to update go 1.19.

https://github.com/topolvm/pvc-autoresizer/actions/runs/4081279918/jobs/7072721083

```
# honnef.co/go/tools/unused
Error: ../../../go/pkg/mod/honnef.co/go/tools@v0.4.0/unused/unused.go:4[19](https://github.com/topolvm/pvc-autoresizer/actions/runs/4081279918/jobs/7072721083#step:7:20):14: obj.Origin undefined (type *types.Var has no field or method Origin)
Error: ../../../go/pkg/mod/honnef.co/go/tools@v0.4.0/unused/unused.go:4[21](https://github.com/topolvm/pvc-autoresizer/actions/runs/4081279918/jobs/7072721083#step:7:22):14: obj.Origin undefined (type *types.Func has no field or method Origin)
note: module requires Go 1.19
```

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>