### PR TITLE
add cert-manager repo in the helm release action

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -16,6 +16,13 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      # Add depending repository for helm to avoid the error below.
+      # `Error: no repository definition for https://charts.jetstack.io`
+      # see: https://github.com/helm/chart-releaser-action/issues/74
+      - name: "Add cert-manager repo for helm"
+        run: |
+          helm repo add cert-manager https://charts.jetstack.io
+
       - name: "Run chart-releaser"
         uses: helm/chart-releaser-action@v1.5.0
         with:


### PR DESCRIPTION
By adding cert-manager to dependency, we met the following error in chart release action.

```
Error: no repository definition for https://charts.jetstack.io/
```

We fixed it in the same way as TopoLVM.
https://github.com/topolvm/topolvm/blob/main/.github/workflows/helm-release.yaml#L26-L31

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>
Co-authored-by: Toshikuni Fukaya <toshikuni-fukaya@cybozu.co.jp>