### PR TITLE
prevent e2e test workflow from running when only updating documents

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,7 +1,13 @@
 name: "e2e"
 on:
   pull_request:
+    paths-ignore:
+        - "**/*.md"
+        - "CODEOWNERS"
   push:
+    paths-ignore:
+        - "**/*.md"
+        - "CODEOWNERS"
     branches:
       - "main"
 jobs:


### PR DESCRIPTION
When only documents are updated, e2e test is not needed to be triggered.
In this PR, I prevent e2e test workflow from runnning when only documents are updated.