### PR TITLE
Move tool versions into versions.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 # Makefile for pvc-autoresizer
 include versions.mk
 
-ENVTEST_K8S_VERSION := $(shell echo $(KUBERNETES_VERSION) | cut -d "." -f 1-2)
-
 ## DON'T EDIT BELOW THIS LINE
 GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -4,8 +4,6 @@ KIND_CLUSTER_NAME := autoresizer-e2e
 
 export KUBERNETES_VERSION
 
-GINKGO_VERSION := $(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print substr($$2, 2)}' ../go.mod)
-
 SUDO := sudo
 BINDIR := $(shell pwd)/../bin
 TMPDIR := /tmp/autoresizer

--- a/versions.mk
+++ b/versions.mk
@@ -7,6 +7,12 @@ KUBE_PROMETHEUS_VERSION := 0.13.0
 KUBERNETES_VERSION ?= 1.27.3
 TOPOLVM_VERSION := topolvm-chart-v12.0.0
 
+ENVTEST_K8S_VERSION := $(shell echo $(KUBERNETES_VERSION) | cut -d "." -f 1-2)
+
+# Tools versions which are defined in go.mod
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+GINKGO_VERSION := $(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print substr($$2, 2)}' $(SELF_DIR)/go.mod)
+
 ifeq ($(KUBERNETES_VERSION),1.27.3)
 KIND_NODE_IMAGE=kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
 else ifeq ($(KUBERNETES_VERSION),1.26.6)


### PR DESCRIPTION
Previously, versions were located at [1], but some were overlooked. This commit consolidates all versions into versions.mk.

[1]: https://github.com/topolvm/pvc-autoresizer/commit/ba88f0079b8a93272575c4a8ccdf08809f791dfd