### PR TITLE
Generating certificates without a cert-manager

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,5 +25,22 @@ jobs:
         with:
           go-version-file: "go.mod"
       - run: make -C e2e setup
-      - run: make -C e2e init-cluster
+      - run: make -C e2e init-app-with-cert-manager
+      - run: make -C e2e test
+
+  e2e-k8s-without-cert-manager:
+    name: "e2e-k8s-without-cert-manager"
+    runs-on: "ubuntu-20.04"
+    strategy:
+      matrix:
+        kubernetes_versions: ["1.27.3", "1.26.6", "1.25.11"]
+    env:
+      KUBERNETES_VERSION: ${{ matrix.kubernetes_versions }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+      - run: make -C e2e setup
+      - run: make -C e2e init-app-without-cert-manager
       - run: make -C e2e test

--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -56,6 +56,8 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | podMonitor.scheme | string | `"http"` | Scheme to use for scraping. |
 | podMonitor.scrapeTimeout | string | `""` | The timeout after which the scrape is ended |
 | webhook.caBundle | string | `nil` | Specify the certificate to be used for AdmissionWebhook. |
+| webhook.certificate.dnsDomain | string | `"cluster.local"` | Cluster DNS domain (required for requesting TLS certificates). |
+| webhook.certificate.generate | bool | `false` | Creates a self-signed certificate for 10 years. Once the validity period has expired, simply delete the tls secret and execute helm upgrade. |
 | webhook.existingCertManagerIssuer | object | `{}` | Specify the cert-manager issuer to be used for AdmissionWebhook. |
 | webhook.pvcMutatingWebhook.enabled | bool | `true` | Enable PVC MutatingWebhook. |
 

--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -57,7 +57,7 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | podMonitor.scrapeTimeout | string | `""` | The timeout after which the scrape is ended |
 | webhook.caBundle | string | `nil` | Specify the certificate to be used for AdmissionWebhook. |
 | webhook.certificate.dnsDomain | string | `"cluster.local"` | Cluster DNS domain (required for requesting TLS certificates). |
-| webhook.certificate.generate | bool | `false` | Creates a self-signed certificate for 10 years. Once the validity period has expired, simply delete the tls secret and execute helm upgrade. |
+| webhook.certificate.generate | bool | `false` | Creates a self-signed certificate for 10 years. Once the validity period has expired, simply delete the controller secret and execute helm upgrade. |
 | webhook.existingCertManagerIssuer | object | `{}` | Specify the cert-manager issuer to be used for AdmissionWebhook. |
 | webhook.pvcMutatingWebhook.enabled | bool | `true` | Enable PVC MutatingWebhook. |
 

--- a/charts/pvc-autoresizer/templates/controller/certificate.yaml
+++ b/charts/pvc-autoresizer/templates/controller/certificate.yaml
@@ -1,4 +1,5 @@
 {{- if not .Values.webhook.caBundle }}
+{{- if not .Values.webhook.certificate.generate }}
 {{- if not .Values.webhook.existingCertManagerIssuer }}
 # Generate a CA Certificate used to sign certificates for the webhook
 apiVersion: cert-manager.io/v1
@@ -51,4 +52,5 @@ spec:
     - key encipherment
     - server auth
     - client auth
+{{- end }}
 {{- end }}

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -78,4 +78,5 @@ spec:
       volumes:
         - name: certs
           secret:
+            defaultMode: 420
             secretName: {{ template "pvc-autoresizer.fullname" . }}-controller

--- a/charts/pvc-autoresizer/templates/controller/issuer.yaml
+++ b/charts/pvc-autoresizer/templates/controller/issuer.yaml
@@ -1,5 +1,6 @@
 {{- if not .Values.webhook.caBundle }}
 {{- if not .Values.webhook.existingCertManagerIssuer }}
+{{- if not .Values.webhook.certificate.generate }}
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
 apiVersion: cert-manager.io/v1
@@ -23,5 +24,6 @@ metadata:
 spec:
   ca:
     secretName: {{ template "pvc-autoresizer.fullname" . }}-webhook-ca
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pvc-autoresizer/templates/controller/mutatingwebhookconfiguration.yaml
+++ b/charts/pvc-autoresizer/templates/controller/mutatingwebhookconfiguration.yaml
@@ -1,12 +1,13 @@
 {{- if .Values.webhook.pvcMutatingWebhook.enabled }}
+{{- $tls := fromYaml ( include "pvc-autoresizer.webhookCerts" . ) }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  {{- if and (not .Values.webhook.caBundle) (not .Values.webhook.certificate.generate) }}
   annotations:
-    {{- if not .Values.webhook.caBundle }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "pvc-autoresizer.fullname" . }}-controller
-    {{- end }}
+  {{- end }}
   labels:
     {{- include "pvc-autoresizer.labels" . | nindent 4 }}
   name: '{{ template "pvc-autoresizer.fullname" . }}-mutating-webhook-configuration'
@@ -14,8 +15,10 @@ webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
-    {{- with .Values.webhook.caBundle }}
-    caBundle: {{ . }}
+    {{- if .Values.webhook.caBundle }}
+    caBundle: {{ .Values.webhook.caBundle }}
+    {{- else if .Values.webhook.certificate.generate }}
+    caBundle: {{ $tls.caCert }}
     {{- end }}
     service:
       name: '{{ template "pvc-autoresizer.fullname" . }}-controller'
@@ -33,4 +36,20 @@ webhooks:
     resources:
     - persistentvolumeclaims
   sideEffects: None
+
+{{- if .Values.webhook.certificate.generate }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "pvc-autoresizer.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pvc-autoresizer.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  ca.crt: {{ $tls.caCert }}
+  tls.crt: {{ $tls.clientCert }}
+  tls.key: {{ $tls.clientKey }}
+{{- end }}
 {{- end }}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -82,6 +82,11 @@ podMonitor:
   additionalLabels: {}
 
 webhook:
+  certificate:
+    # webhook.certificate.generate --  Creates a self-signed certificate for 10 years. Once the validity period has expired, simply delete the controller secret and execute helm upgrade.
+    generate: false
+    # webhook.certificate.dnsDomain --  Cluster DNS domain (required for requesting TLS certificates).
+    dnsDomain: cluster.local
   # webhook.caBundle -- Specify the certificate to be used for AdmissionWebhook.
   caBundle:  # Base64-encoded, PEM-encoded CA certificate that signs the server certificate.
   # webhook.existingCertManagerIssuer -- Specify the cert-manager issuer to be used for AdmissionWebhook.

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -33,9 +33,16 @@ init-cluster: launch-kind autoresizer.img kube-prometheus
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo update
 	$(HELM) dependency build ../charts/pvc-autoresizer/
-	$(HELM) install --create-namespace --namespace=pvc-autoresizer pvc-autoresizer ../charts/pvc-autoresizer/ -f manifests/values/values.yaml
 	# storageclass for test
 	$(KUBECTL) apply -f manifests/common/storageclass.yaml
+
+.PHONY: init-app-with-cert-manager
+init-app-with-cert-manager: init-cluster
+	$(HELM) install --create-namespace --namespace=pvc-autoresizer pvc-autoresizer ../charts/pvc-autoresizer/ -f manifests/values/values.yaml
+
+.PHONY: init-app-without-cert-manager
+init-app-without-cert-manager: init-cluster
+	$(HELM) install --create-namespace --namespace=pvc-autoresizer pvc-autoresizer ../charts/pvc-autoresizer/ -f manifests/values/values-without-cert-manager.yaml
 
 .PHONY: test
 test:

--- a/e2e/manifests/values/values-without-cert-manager.yaml
+++ b/e2e/manifests/values/values-without-cert-manager.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: pvc-autoresizer
+  tag: devel
+  pullPolicy: Never
+
+controller:
+  args:
+    prometheusURL: http://prometheus-k8s.monitoring.svc:9090
+    interval: 1s
+
+webhook:
+  certificate:
+    generate: true


### PR DESCRIPTION
What should the feature do:
Automatically create a certificate for a webhook in the absence of a cert-manager

What is use case behind this feature:
There is no need to install extra applications in the cluster and support them (cert-manager)

#223 