### PR TITLE
Update release procedure

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,24 +45,7 @@ Bump version
     VERSION=1.2.3
     ```
 
-2. Make a branch for the release as follows:
-
-    ```console
-    git switch main
-    git pull
-    git switch -c bump-$VERSION
-    ```
-
-3. Change `TOPOLVM_VERSION` in `versions.mk` to the latest topolvm chart release tag. (e.g. topolvm-chart-vX.Y.Z)
-4. Commit the change and create a pull request:
-
-    ```console
-    git commit -a -s -m "Bump version to $VERSION"
-    git push -u origin bump-$VERSION
-    ```
-
-5. Merge the new pull request.
-6. Add a new tag and push it as follows:
+2. Add a new tag and push it as follows:
 
     ```console
     git switch main
@@ -71,7 +54,7 @@ Bump version
     git push origin v$VERSION
     ```
 
-7. Once a new tag is pushed, [GitHub Actions][] automatically
+3. Once a new tag is pushed, [GitHub Actions][] automatically
    creates a draft release note for the tagged version,
    builds a tar archive for the new release,
    and attaches it to the release note.
@@ -79,7 +62,7 @@ Bump version
    Visit https://github.com/topolvm/pvc-autoresizer/releases to check
    the result. 
 
-8. Edit the auto-generated release note
+4. Edit the auto-generated release note
    and remove PRs which contain changes only to the helm chart.
    Then, publish it.
 


### PR DESCRIPTION
Technically, pvc-autoresizer does not depend on topolvm. Note that pvc-autoresizer uses kind environment for CI, which is set up by scripts on topolvm repository. It should be updated on changing supported kubernetes version.