### PR TITLE
pin setup-envtest to go 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ SETUP_ENVTEST := $(BINDIR)/setup-envtest
 setup-envtest: $(SETUP_ENVTEST) ## Download setup-envtest locally if necessary
 $(SETUP_ENVTEST):
 	# see https://github.com/kubernetes-sigs/controller-runtime/tree/master/tools/setup-envtest
-	GOBIN=$(BINDIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(BINDIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: setup
 setup: # Setup tools

--- a/versions.mk
+++ b/versions.mk
@@ -14,6 +14,11 @@ KUBE_PROMETHEUS_VERSION := 0.13.0
 KUBERNETES_VERSION ?= 1.28.0
 TOPOLVM_VERSION := topolvm-chart-v14.0.0
 
+# ENVTEST_VERSION is usually latest, but might need to be pinned from time to time.
+# Version pinning is needed due to version incompatibility between controller-runtime and setup-envtest.
+# For more information: https://github.com/kubernetes-sigs/controller-runtime/issues/2744
+ENVTEST_VERSION := bf15e44028f908c790721fc8fe67c7bf2d06a611
+
 ENVTEST_K8S_VERSION := $(shell echo $(KUBERNETES_VERSION) | cut -d "." -f 1-2)
 
 # Tools versions which are defined in go.mod


### PR DESCRIPTION
Currently, the CI is broken because the latest setup-envtest requires go 1.21 ([an example failed run](https://github.com/topolvm/pvc-autoresizer/actions/runs/8549418063/job/23424700661?pr=249)). This patch solves this problem by pinning setup-envtest to go 1.20.

See also:
- https://github.com/topolvm/topolvm/pull/865
- https://github.com/kubernetes-sigs/controller-runtime/issues/2744
- https://github.com/topolvm/pie/pull/115