### PR TITLE
add CLI options for tuning logging

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/spf13/cobra"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -21,6 +23,7 @@ var config struct {
 	useK8sMetricsApi bool
 	skipAnnotation   bool
 	development      bool
+	zapOpts          zap.Options
 }
 
 // rootCmd represents the base command when called without any subcommands
@@ -55,4 +58,8 @@ func init() {
 	fs.BoolVar(&config.useK8sMetricsApi, "use-k8s-metrics-api", false, "Use Kubernetes metrics API instead of Prometheus")
 	fs.BoolVar(&config.skipAnnotation, "no-annotation-check", false, "Skip annotation check for StorageClass")
 	fs.BoolVar(&config.development, "development", false, "Use development logger config")
+
+	goflags := flag.NewFlagSet("zap", flag.ExitOnError)
+	config.zapOpts.BindFlags(goflags)
+	fs.AddGoFlagSet(goflags)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -35,7 +35,10 @@ func init() {
 }
 
 func subMain() error {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(config.development)))
+	if config.development {
+		config.zapOpts.Development = true
+	}
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&config.zapOpts)))
 
 	hookHost, portStr, err := net.SplitHostPort(config.webhookAddr)
 	if err != nil {


### PR DESCRIPTION
Fix #259 


This commit adds the following CLI options to tune logging:

- `-zap-devel`
- `-zap-encoder`
- `-zap-log-level`
- `-zap-stacktrace-level`
- `-zap-time-encoding`

See also: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log/zap#Options.BindFlags
