### PR TITLE
Avoid using github.com/pkg/errors directly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-logr/logr v1.4.1
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/client_model v0.5.0
 	github.com/prometheus/common v0.45.0
@@ -48,6 +47,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/internal/runners/k8s_metrics_api_client.go
+++ b/internal/runners/k8s_metrics_api_client.go
@@ -3,9 +3,9 @@ package runners
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync"
 
-	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/topolvm/pvc-autoresizer/internal/metrics"
@@ -90,12 +90,12 @@ func getPVCUsageFromK8sMetricsAPI(
 		Suffix("metrics")
 	respBody, err := req.DoRaw(ctx)
 	if err != nil {
-		return nil, errors.Errorf("failed to get stats from kubelet on node %s: with error %s", nodeName, err)
+		return nil, fmt.Errorf("failed to get stats from kubelet on node %s: %w", nodeName, err)
 	}
 	parser := expfmt.TextParser{}
 	metricFamilies, err := parser.TextToMetricFamilies(bytes.NewReader(respBody))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read response body from kubelet on node %s", nodeName)
+		return nil, fmt.Errorf("failed to read response body from kubelet on node %s: %w", nodeName, err)
 	}
 
 	pvcUsage := make(map[types.NamespacedName]*VolumeStats)


### PR DESCRIPTION
The go module "github.com/pkg/errors" had been archived on 2021. In this commit we avoid using this module directly and use fmt.Errorf() from the standard library instead.
