### PR TITLE
fix: optionally disable the webhook server

### DIFF
--- a/charts/pvc-autoresizer/templates/controller/certificate.yaml
+++ b/charts/pvc-autoresizer/templates/controller/certificate.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.pvcMutatingWebhook.enabled }}
 {{- if not .Values.webhook.caBundle }}
 {{- if not .Values.webhook.certificate.generate }}
 {{- if not .Values.webhook.existingCertManagerIssuer }}
@@ -52,5 +53,6 @@ spec:
     - key encipherment
     - server auth
     - client auth
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- if not .Values.webhook.pvcMutatingWebhook.enabled }}
-            - --webhook-enabled=false
+            - --pvc-mutating-webhook-enabled=false
           {{- end}}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           {{- with .Values.image.pullPolicy }}

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -42,6 +42,9 @@ spec:
           {{- with .Values.controller.args.additionalArgs -}}
             {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- if not .Values.webhook.pvcMutatingWebhook.enabled }}
+            - --webhook-enabled=false
+          {{- end}}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           {{- with .Values.image.pullPolicy }}
           imagePullPolicy: {{ . }}
@@ -67,9 +70,11 @@ spec:
             httpGet:
               path: /healthz
               port: health
+          {{- if .Values.webhook.pvcMutatingWebhook.enabled }}
           volumeMounts:
             - name: certs
               mountPath: /certs
+          {{- end }}
           securityContext:
             {{- toYaml .Values.controller.securityContext | nindent 12 }}
     {{- with .Values.controller.nodeSelector }}
@@ -80,10 +85,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      {{- if .Values.webhook.pvcMutatingWebhook.enabled }}
       volumes:
         - name: certs
           secret:
             defaultMode: 420
             secretName: {{ template "pvc-autoresizer.fullname" . }}-controller
+      {{- end }}
       securityContext:
         {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}

--- a/charts/pvc-autoresizer/templates/controller/issuer.yaml
+++ b/charts/pvc-autoresizer/templates/controller/issuer.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.pvcMutatingWebhook.enabled }}
 {{- if not .Values.webhook.caBundle }}
 {{- if not .Values.webhook.existingCertManagerIssuer }}
 {{- if not .Values.webhook.certificate.generate }}
@@ -24,6 +25,7 @@ metadata:
 spec:
   ca:
     secretName: {{ template "pvc-autoresizer.fullname" . }}-webhook-ca
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ var config struct {
 	skipAnnotation   bool
 	development      bool
 	zapOpts          zap.Options
+	webhookEnabled   bool
 }
 
 // rootCmd represents the base command when called without any subcommands
@@ -58,6 +59,7 @@ func init() {
 	fs.BoolVar(&config.useK8sMetricsApi, "use-k8s-metrics-api", false, "Use Kubernetes metrics API instead of Prometheus")
 	fs.BoolVar(&config.skipAnnotation, "no-annotation-check", false, "Skip annotation check for StorageClass")
 	fs.BoolVar(&config.development, "development", false, "Use development logger config")
+	fs.BoolVar(&config.webhookEnabled, "webhook-enabled", true, "Enable the webhook endpoint")
 
 	goflags := flag.NewFlagSet("zap", flag.ExitOnError)
 	config.zapOpts.BindFlags(goflags)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,18 +13,18 @@ import (
 )
 
 var config struct {
-	certDir          string
-	webhookAddr      string
-	metricsAddr      string
-	healthAddr       string
-	namespaces       []string
-	watchInterval    time.Duration
-	prometheusURL    string
-	useK8sMetricsApi bool
-	skipAnnotation   bool
-	development      bool
-	zapOpts          zap.Options
-	webhookEnabled   bool
+	certDir                   string
+	webhookAddr               string
+	metricsAddr               string
+	healthAddr                string
+	namespaces                []string
+	watchInterval             time.Duration
+	prometheusURL             string
+	useK8sMetricsApi          bool
+	skipAnnotation            bool
+	development               bool
+	zapOpts                   zap.Options
+	pvcMutatingWebhookEnabled bool
 }
 
 // rootCmd represents the base command when called without any subcommands
@@ -59,7 +59,8 @@ func init() {
 	fs.BoolVar(&config.useK8sMetricsApi, "use-k8s-metrics-api", false, "Use Kubernetes metrics API instead of Prometheus")
 	fs.BoolVar(&config.skipAnnotation, "no-annotation-check", false, "Skip annotation check for StorageClass")
 	fs.BoolVar(&config.development, "development", false, "Use development logger config")
-	fs.BoolVar(&config.webhookEnabled, "webhook-enabled", true, "Enable the webhook endpoint")
+	fs.BoolVar(&config.pvcMutatingWebhookEnabled, "pvc-mutating-webhook-enabled", true,
+		"Enable the pvc mutating webhook endpoint")
 
 	goflags := flag.NewFlagSet("zap", flag.ExitOnError)
 	config.zapOpts.BindFlags(goflags)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -41,7 +41,7 @@ func subMain() error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&config.zapOpts)))
 
 	var webhookServer webhook.Server
-	if config.webhookEnabled {
+	if config.pvcMutatingWebhookEnabled {
 		hookHost, portStr, err := net.SplitHostPort(config.webhookAddr)
 		if err != nil {
 			setupLog.Error(err, "invalid webhook addr")
@@ -106,7 +106,7 @@ func subMain() error {
 	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
 		return err
 	}
-	if config.webhookEnabled {
+	if config.pvcMutatingWebhookEnabled {
 		if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
 			return err
 		}
@@ -140,7 +140,7 @@ func subMain() error {
 		return err
 	}
 
-	if config.webhookEnabled {
+	if config.pvcMutatingWebhookEnabled {
 		dec := admission.NewDecoder(scheme)
 		if err = hooks.SetupPersistentVolumeClaimWebhook(mgr, dec, ctrl.Log.WithName("hooks")); err != nil {
 			setupLog.Error(err, "unable to create PersistentVolumeClaim webhook")


### PR DESCRIPTION
Fixes https://github.com/topolvm/pvc-autoresizer/issues/271

When `.Values.webhook.pvcMutatingWebhook.enabled` is set false, ensure that any of the configuration related to the webhook server is not rendered. ie. cert manager certificate / issuer, deployment volume mount from secret etc.
This is supplemented with a new option `--webhook-enabled` - which by default is set true, to mirror existing behaviour. When it is explicitly set false, for example when `.Values.webhook.pvcMutatingWebhook.enabled` is set false the webhook server will not be configured.

ie.
```
helm install pvc-autoresizer ./charts/pvc-autoresizer --create-namespace --namespace=pvc-autoresizer --set "controller.args.prometheusURL=http://prom-kube-prometheus-stack-prometheus.default.svc:9090/" --set "image.tag=devel" --set "webhook.pvcMutatingWebhook.enabled=false"
NAME: pvc-autoresizer
LAST DEPLOYED: Mon Jul  8 11:51:45 2024
NAMESPACE: pvc-autoresizer
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

```
kubectl -n pvc-autoresizer logs -l app.kubernetes.io/name=pvc-autoresizer --since 24h -f
{"level":"info","ts":"2024-07-08T10:51:46Z","logger":"setup","msg":"starting manager"}
{"level":"info","ts":"2024-07-08T10:51:46Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2024-07-08T10:51:46Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
{"level":"info","ts":"2024-07-08T10:51:46Z","msg":"starting server","kind":"health probe","addr":"[::]:8081"}
I0708 10:51:46.417637       1 leaderelection.go:250] attempting to acquire leader lease pvc-autoresizer/49e22f61.topolvm.io...
I0708 10:51:46.422308       1 leaderelection.go:260] successfully acquired lease pvc-autoresizer/49e22f61.topolvm.io
```