### PR TITLE
fix: cert-manager duration expects XhYmZs format

### DIFF
--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -37,6 +37,7 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | controller.args.namespaces | list | `[]` | Specify namespaces to control the pvcs of. Empty for all namespaces. Used as "--namespaces" option |
 | controller.args.prometheusURL | string | `"http://prometheus-prometheus-oper-prometheus.prometheus.svc:9090"` | Specify Prometheus URL to query volume stats. Used as "--prometheus-url" option |
 | controller.args.useK8sMetricsApi | bool | `false` | Use Kubernetes metrics API instead of Prometheus. Used as "--use-k8s-metrics-api" option |
+| controller.certificate.duration | string | `"8760h0m0s"` | The duration of the TLS certificate for the webhook |
 | controller.nodeSelector | object | `{}` | Map of key-value pairs for scheduling pods on specific nodes. |
 | controller.podAnnotations | object | `{}` | Annotations to be added to controller pods. |
 | controller.podLabels | object | `{}` | Pod labels to be added to controller pods. |

--- a/charts/pvc-autoresizer/templates/controller/certificate.yaml
+++ b/charts/pvc-autoresizer/templates/controller/certificate.yaml
@@ -34,7 +34,7 @@ metadata:
     {{- include "pvc-autoresizer.labels" . | nindent 4 }}
 spec:
   secretName: {{ template "pvc-autoresizer.fullname" . }}-controller
-  duration: 8760h0m0s # 1y
+  duration: {{ .Values.controller.certificate.duration | quote }}
   issuerRef:
     {{- with .Values.webhook.existingCertManagerIssuer }}
     {{- toYaml . | nindent 4 -}}

--- a/charts/pvc-autoresizer/templates/controller/certificate.yaml
+++ b/charts/pvc-autoresizer/templates/controller/certificate.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "pvc-autoresizer.labels" . | nindent 4 }}
 spec:
   secretName: {{ template "pvc-autoresizer.fullname" . }}-webhook-ca
-  duration: 87600h # 10y
+  duration: 87600h0m0s # 10y
   issuerRef:
     group: cert-manager.io
     kind: Issuer
@@ -34,7 +34,7 @@ metadata:
     {{- include "pvc-autoresizer.labels" . | nindent 4 }}
 spec:
   secretName: {{ template "pvc-autoresizer.fullname" . }}-controller
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     {{- with .Values.webhook.existingCertManagerIssuer }}
     {{- toYaml . | nindent 4 -}}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -13,6 +13,10 @@ controller:
   # controller.replicas -- Specify the number of replicas of the controller Pod.
   replicas: 1
 
+  certificate:
+    # controller.certificate.duration -- The duration of the TLS certificate for the webhook
+    duration: 8760h0m0s # 1y
+
   args:
     # controller.args.useK8sMetricsApi -- Use Kubernetes metrics API instead of Prometheus.
     # Used as "--use-k8s-metrics-api" option


### PR DESCRIPTION
It accepts shorter format like Yh, but the mutating webhook, if
installed/enabled will convert it to the full format, causing potential
endless reconciliation loops with tools like ArgoCD

Fixes #190
