### PR TITLE
Update the release procedure to check if a new release is required

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,13 +39,13 @@ The result should look something like:
 Bump version
 ------------
 
-1. Go to [the rule setting page](https://github.com/topolvm/pvc-autoresizer/settings/rules/2151118) and change the value of "Enforcement status" to `Active`.
-
-2. Determine a new version number by [checking the differences](https://github.com/topolvm/pvc-autoresizer/compare/vX.Y.Z...main) since the last release. Then, define the `VERSION` variable.
+1. Check if a new release is required by [checking the differences](https://github.com/topolvm/pvc-autoresizer/compare/vX.Y.Z...main) since the last release. If so, determine a new version number and define the `VERSION` variable.
 
     ```console
     VERSION=1.2.3
     ```
+
+2. Go to [the rule setting page](https://github.com/topolvm/pvc-autoresizer/settings/rules/2151118) and change the value of "Enforcement status" to `Active`.
 
 3. Add a new tag and push it as follows:
 


### PR DESCRIPTION
We release a new version of pvc-autoresizer and its chart every month, but if there aren't any significant changes, we might skip that month's release.