### PR TITLE
Add additional configuration options for the chart ServiceAccount

### DIFF
--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -61,6 +61,8 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | podMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping. |
 | podMonitor.scheme | string | `"http"` | Scheme to use for scraping. |
 | podMonitor.scrapeTimeout | string | `""` | The timeout after which the scrape is ended |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Controls the automatic mounting of ServiceAccount API credentials. |
+| serviceAccount.enabled | bool | `true` | Creates a ServiceAccount for the controller deployment. |
 | webhook.caBundle | string | `nil` | Specify the certificate to be used for AdmissionWebhook. |
 | webhook.certificate.dnsDomain | string | `"cluster.local"` | Cluster DNS domain (required for requesting TLS certificates). |
 | webhook.certificate.generate | bool | `false` | Creates a self-signed certificate for 10 years. Once the validity period has expired, simply delete the controller secret and execute helm upgrade. |

--- a/charts/pvc-autoresizer/templates/controller/serviceaccount.yaml
+++ b/charts/pvc-autoresizer/templates/controller/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pvc-autoresizer.labels" . | nindent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -151,3 +151,9 @@ cert-manager:
   # cert-manager.enabled -- Install cert-manager together.
   ## ref: https://cert-manager.io/docs/installation/helm/#installing-with-helm
   enabled: false
+
+serviceAccount:
+  # serviceAccount.enabled -- Creates a ServiceAccount for the controller deployment.
+  enabled: true
+  # serviceAccount.automountServiceAccountToken -- Controls the automatic mounting of ServiceAccount API credentials.
+  automountServiceAccountToken: true


### PR DESCRIPTION
Some users of the chart might need to adjust the `automountServiceAccountToken` value of the chart's ServiceAccount, or may want to supply their own ServiceAccount template instead. This change adds configuration options to allow these customizations.