### PR TITLE
Update the controller deployment labels to include more standard labels and use selector labels

### DIFF
--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -12,12 +12,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: pvc-autoresizer
+      {{- include "pvc-autoresizer.selectorLabels" . | nindent 6 }}
   replicas: {{ .Values.controller.replicas }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: pvc-autoresizer
+        {{- include "pvc-autoresizer.labels" . | nindent 8 }}
         {{- with .Values.controller.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/pvc-autoresizer/templates/controller/podmonitor.yaml
+++ b/charts/pvc-autoresizer/templates/controller/podmonitor.yaml
@@ -18,7 +18,7 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: pvc-autoresizer
+      {{- include "pvc-autoresizer.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
     - port: metrics
       path: /metrics

--- a/charts/pvc-autoresizer/templates/controller/service.yaml
+++ b/charts/pvc-autoresizer/templates/controller/service.yaml
@@ -9,5 +9,5 @@ spec:
     - port: 443
       targetPort: 9443
   selector:
-    app.kubernetes.io/name: pvc-autoresizer
+    {{- include "pvc-autoresizer.selectorLabels" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
The current way the deployment labels are configured means the pods have only the `app.kubernetes.io/name` label by default. While users can add additional labels using the `controller.podLabels` value, generally it would be nice to provide the common labels (already generated in the tpl) on the pods by default.

Additionally, the current deployment `spec.selector.matchLabels` is hardcoded to a single static `app.kubernetes.io/name: pvc-autoresizer` label. This prevents users from running multiple deployments in the same cluster which can be useful in dev environments. A tpl function to generate the selector labels is already present so this change simply switches to using that.

This issue also applies to other resources like the PodMonitor and Service, so those have been updated to use the selector labels as well.