### PR TITLE
Patch annotations onto STS provisioned PVCs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.vscode
 /.idea
 /vendor
+.DS_Store
 
 # ignore dependency charts
 charts/*/charts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This file itself is based on [Keep a CHANGELOG](https://keepachangelog.com/en/0.
 
 ## [Unreleased]
 
+### Added
+- Add option allowing PVC autoresizer to update annotations of STS provisioned PVCs to match the volumeClaimTemplate ([#306](https://github.com/topolvm/pvc-autoresizer/pull/306))
+
 ## [0.10.0] - 2023-10-13
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ CONTROLLER_GEN := $(BINDIR)/controller-gen
 GOLANGCI_LINT = $(BINDIR)/golangci-lint
 KUBECTL := $(BINDIR)/kubectl
 KUSTOMIZE := $(BINDIR)/kustomize
+SETUP_ENVTEST := $(BINDIR)/setup-envtest
 
-KUBEBUILDER_ASSETS := $(BINDIR)
+KUBEBUILDER_ASSETS := $(shell $(SETUP_ENVTEST) use -p path $(ENVTEST_K8S_VERSION))
 export KUBEBUILDER_ASSETS
 
 IMAGE_TAG ?= latest
@@ -142,7 +143,6 @@ staticcheck: ## Install staticcheck
 		env GOFLAGS= go install honnef.co/go/tools/cmd/staticcheck@latest; \
 	fi
 
-SETUP_ENVTEST := $(BINDIR)/setup-envtest
 .PHONY: setup-envtest
 setup-envtest: $(SETUP_ENVTEST) ## Download setup-envtest locally if necessary
 $(SETUP_ENVTEST):

--- a/charts/pvc-autoresizer/Chart.yaml
+++ b/charts/pvc-autoresizer/Chart.yaml
@@ -18,18 +18,18 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.17.0
+appVersion: 0.18.0
 
 annotations:
   artifacthub.io/images: |
     - name: pvc-autoresizer
-      image: ghcr.io/topolvm/pvc-autoresizer:0.17.0
+      image: ghcr.io/topolvm/pvc-autoresizer:0.18.0
   artifacthub.io/license: Apache-2.0
 
 dependencies:

--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -35,6 +35,7 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | controller.affinity | object | `{}` | Affinity for controller deployment. |
 | controller.annotations | object | `{}` | Annotations to be added to controller deployment. |
 | controller.args.additionalArgs | list | `[]` | Specify additional args. |
+| controller.args.annotationPatchingEnabled | bool | `false` | Automatically patch annotations of STS provisioned PVCs to match volumeClaimTemplates. Used as "--annotation-patching-enabled" option |
 | controller.args.interval | string | `"10s"` | Specify interval to monitor pvc capacity. Used as "--interval" option |
 | controller.args.namespaces | list | `[]` | Specify namespaces to control the pvcs of. Empty for all namespaces. Used as "--namespaces" option |
 | controller.args.prometheusURL | string | `"http://prometheus-prometheus-oper-prometheus.prometheus.svc:9090"` | Specify Prometheus URL to query volume stats. Used as "--prometheus-url" option |

--- a/charts/pvc-autoresizer/templates/controller/clusterrole.yaml
+++ b/charts/pvc-autoresizer/templates/controller/clusterrole.yaml
@@ -58,3 +58,12 @@ rules:
   - list
   - watch
 {{- end }}
+{{- if .Values.controller.args.annotationPatchingEnabled }}
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - watch
+{{- end }}

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -43,6 +43,9 @@ spec:
           {{- if .Values.controller.args.namespaces }}
             - --namespaces={{ join "," .Values.controller.args.namespaces }}
           {{- end }}
+          {{- if .Values.controller.args.annotationPatchingEnabled }}
+            - --annotation-patching-enabled={{ .Values.controller.args.annotationPatchingEnabled }}
+          {{- end }}
           {{- with .Values.controller.args.additionalArgs -}}
             {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -4,7 +4,7 @@ image:
 
   # image.tag -- pvc-autoresizer image tag to use.
   # @default -- `{{ .Chart.AppVersion }}`
-  tag:  # 0.17.0
+  tag:  # 0.18.0
 
   # image.pullPolicy -- pvc-autoresizer image pullPolicy.
   pullPolicy:  # Always
@@ -29,6 +29,10 @@ controller:
     # controller.args.interval -- Specify interval to monitor pvc capacity.
     # Used as "--interval" option
     interval: 10s
+
+    # controller.args.annotationPatchingEnabled -- Automatically patch annotations of STS provisioned PVCs to match volumeClaimTemplates.
+    # Used as "--annotation-patching-enabled" option
+    annotationPatchingEnabled: false
 
     # controller.args.additionalArgs -- Specify additional args.
     additionalArgs: []

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ var config struct {
 	development               bool
 	zapOpts                   zap.Options
 	pvcMutatingWebhookEnabled bool
+	annotationPatchingEnabled bool
 }
 
 // rootCmd represents the base command when called without any subcommands
@@ -61,6 +62,8 @@ func init() {
 	fs.BoolVar(&config.development, "development", false, "Use development logger config")
 	fs.BoolVar(&config.pvcMutatingWebhookEnabled, "pvc-mutating-webhook-enabled", true,
 		"Enable the pvc mutating webhook endpoint")
+	fs.BoolVar(&config.annotationPatchingEnabled, "annotation-patching-enabled", false,
+		"For STS provisioned PVCs, patch annotations in the STS volumeClaimTemplate onto PVCs.")
 
 	goflags := flag.NewFlagSet("zap", flag.ExitOnError)
 	config.zapOpts.BindFlags(goflags)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,6 +24,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses

--- a/constants.go
+++ b/constants.go
@@ -1,25 +1,30 @@
 package pvcautoresizer
 
+const AutoResizerAnnotationPrefix = "resize.topolvm.io/"
+
 // AutoResizeEnabledKey is the key of flag that enables pvc-autoresizer.
-const AutoResizeEnabledKey = "resize.topolvm.io/enabled"
+const AutoResizeEnabledKey = AutoResizerAnnotationPrefix + "enabled"
 
 // ResizeThresholdAnnotation is the key of resize threshold.
-const ResizeThresholdAnnotation = "resize.topolvm.io/threshold"
+const ResizeThresholdAnnotation = AutoResizerAnnotationPrefix + "threshold"
 
 // ResizeInodesThresholdAnnotation is the key of resize threshold for inodes.
-const ResizeInodesThresholdAnnotation = "resize.topolvm.io/inodes-threshold"
+const ResizeInodesThresholdAnnotation = AutoResizerAnnotationPrefix + "inodes-threshold"
 
 // ResizeIncreaseAnnotation is the key of amount increased.
-const ResizeIncreaseAnnotation = "resize.topolvm.io/increase"
+const ResizeIncreaseAnnotation = AutoResizerAnnotationPrefix + "increase"
 
 // StorageLimitAnnotation is the key of storage limit value
-const StorageLimitAnnotation = "resize.topolvm.io/storage_limit"
+const StorageLimitAnnotation = AutoResizerAnnotationPrefix + "storage_limit"
 
 // PreviousCapacityBytesAnnotation is the key of previous volume capacity.
-const PreviousCapacityBytesAnnotation = "resize.topolvm.io/pre_capacity_bytes"
+const PreviousCapacityBytesAnnotation = AutoResizerAnnotationPrefix + "pre_capacity_bytes"
 
 // InitialResizeGroupByAnnotation is the key of the initial-resize group by.
-const InitialResizeGroupByAnnotation = "resize.topolvm.io/initial-resize-group-by"
+const InitialResizeGroupByAnnotation = AutoResizerAnnotationPrefix + "initial-resize-group-by"
+
+// AnnotationPatchingEnabled is the key of flag that enables patching of annotations for STS provisioned PVCs.
+const AnnotationPatchingEnabled = AutoResizerAnnotationPrefix + "annotation-patching-enabled"
 
 // DefaultThreshold is the default value of ResizeThresholdAnnotation.
 const DefaultThreshold = "10%"


### PR DESCRIPTION
## Overview

This change allows for automated reconciliation of PVC autoresize annotations on STS provisioned PVCs. This is opt-in behavior so existing users won't be affected unless they want the functionality. This only manages the following annotations:

- `resize.topolvm.io/threshold`
- `resize.topolvm.io/inodes-threshold`
- `resize.topolvm.io/increase`
- `resize.topolvm.io/storage_limit`
- `resize.topolvm.io/initial-resize-group-by`

Fixes #304

## Testing

Unit tests were added covering both the new functionality and the new metrics associated with annotation patching.

## Other

I made some other minor updates to the `Makefile` and unit test setup as the existing `make test` command was not working for me due to running in a subshell I believe. The unit test changes were only around setting the log level to debug as failing tests may be easier to debug that way. Happy to remove these changes if they are not desired.