### PR TITLE
Adds multi-platform support (and ARM64 compat)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,6 +10,10 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - uses: actions/checkout@v4
+      - name: "Set up QEMU"
+        uses: docker/setup-qemu-action@v3
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,10 @@ jobs:
           echo "version=${VERSION}" >> ${GITHUB_OUTPUT}
           echo "prerelease=${PRERELEASE}" >> ${GITHUB_OUTPUT}
       - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: "Set up QEMU"
+        uses: docker/setup-qemu-action@v3
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
@@ -27,13 +31,13 @@ jobs:
       - run: make setup
       - run: make image
       - run: make tag IMAGE_TAG=${{ steps.check_version.outputs.version }}
-      - run: make push IMAGE_TAG=${{ steps.check_version.outputs.version }}
+      - run: make multi-platform-image IMAGE_TAG=${{ steps.check_version.outputs.version }} PUSH=true
       - name: "Push branch tag"
         if: ${{ steps.check_version.outputs.prerelease == 'false' }}
         run: |
           BRANCH=$(echo ${{ steps.check_version.outputs.version }} | cut -d "." -f 1-2)
           make tag IMAGE_TAG=$BRANCH
-          make push IMAGE_TAG=$BRANCH
+          make multi-platform-image IMAGE_TAG=$BRANCH PUSH=true
       - name: "Get previous tag"
         id: get_previous_tag
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Stage1: Build the pvc-autoresizer binary
-FROM golang:1.23 as builder
+FROM --platform=$BUILDPLATFORM golang:1.23 as builder
+
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -11,7 +13,7 @@ COPY cmd/ cmd/
 COPY internal/ internal/
 
 # Build
-RUN CGO_ENABLED=0 go build -ldflags="-w -s" -a -o pvc-autoresizer cmd/*.go
+RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -ldflags="-w -s" -a -o pvc-autoresizer cmd/*.go
 
 # Stage2: setup runtime container
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ IMAGE_PREFIX ?= ghcr.io/topolvm/
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+PUSH ?= false
+BUILDX_PUSH_OPTIONS := --load
+ifeq ($(PUSH),true)
+BUILDX_PUSH_OPTIONS := --push
+endif
+
 .PHONY: all
 all: build
 
@@ -96,7 +102,14 @@ run: manifests generate ## Run a controller from your host.
 
 .PHONY: image
 image: ## Build docker image.
-	docker build . -t $(IMAGE_PREFIX)pvc-autoresizer:devel
+	docker build -t $(IMAGE_PREFIX)pvc-autoresizer:devel .
+
+.PHONY: multi-platform-image
+multi-platform-image: ## Build multi-platform docker image.
+	docker buildx build --no-cache $(BUILDX_PUSH_OPTIONS) \
+		--platform linux/amd64,linux/arm64 \
+		-t $(IMAGE_PREFIX)pvc-autoresizer:$(IMAGE_TAG) \
+		.
 
 .PHONY: tag
 tag: ## Set a docker tag to the image.


### PR DESCRIPTION
This PR makes pvc-autoresizer container images available for linux/arm64 in addition to the current linux/amd64.

I updated the Dockerfile, Makefile, and GitHub Actions to use docker buildx and QEMU, just like the upstream topolvm project does. This keeps pvc-autoresizer build process consistent with the one from TopoLVM.

Resolves #267, resolves #299 