### PR TITLE
Reduce image build time

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,15 +29,12 @@ jobs:
         with:
           go-version-file: "go.mod"
       - run: make setup
-      - run: make image
-      - run: make tag IMAGE_TAG=${{ steps.check_version.outputs.version }}
       - run: make multi-platform-image IMAGE_TAG=${{ steps.check_version.outputs.version }} PUSH=true
       - name: "Push branch tag"
         if: ${{ steps.check_version.outputs.prerelease == 'false' }}
         run: |
           BRANCH=$(echo ${{ steps.check_version.outputs.version }} | cut -d "." -f 1-2)
-          make tag IMAGE_TAG=$BRANCH
-          make multi-platform-image IMAGE_TAG=$BRANCH PUSH=true
+          make tag IMAGE_TAG=$BRANCH ORIGINAL_IMAGE_TAG=${{ steps.check_version.outputs.version }}
       - name: "Get previous tag"
         id: get_previous_tag
         run: |

--- a/Makefile
+++ b/Makefile
@@ -113,11 +113,9 @@ multi-platform-image: ## Build multi-platform docker image.
 
 .PHONY: tag
 tag: ## Set a docker tag to the image.
-	docker tag $(IMAGE_PREFIX)pvc-autoresizer:devel $(IMAGE_PREFIX)pvc-autoresizer:$(IMAGE_TAG)
-
-.PHONY: push
-push: ## Push docker image.
-	docker push $(IMAGE_PREFIX)pvc-autoresizer:$(IMAGE_TAG)
+	docker buildx imagetools create \
+		--tag $(IMAGE_PREFIX)pvc-autoresizer:$(IMAGE_TAG) \
+		$(IMAGE_PREFIX)pvc-autoresizer:$(ORIGINAL_IMAGE_TAG)
 
 ##@ Chart Testing
 


### PR DESCRIPTION
We initially used `docker buildx build` to support multiple CPU architectures[1]. However, we forgot to remove the make image command that runs `docker build`, which was redundant, so we decided to eliminate it. Another inefficiency arose from setting the branch tag. The image is conceptually the same as the fully versioned one, but we were running another `docker buildx build`, resulting in the creation of an additional image. To address this, we now use `docker buildx imagetools create` to set the branch tag on the existing image.

[1]: 99b821c (Adds multi-platform support (and ARM64 compat))