### PR TITLE
Add namespace scope to the mutation webhook

### DIFF
--- a/charts/pvc-autoresizer/templates/controller/mutatingwebhookconfiguration.yaml
+++ b/charts/pvc-autoresizer/templates/controller/mutatingwebhookconfiguration.yaml
@@ -35,6 +35,7 @@ webhooks:
     - CREATE
     resources:
     - persistentvolumeclaims
+    scope: Namespaced
   sideEffects: None
 
 {{- if .Values.webhook.certificate.generate }}


### PR DESCRIPTION
On my cluster 1.33.4 it was not listening to all PVC (cf. https://github.com/topolvm/pvc-autoresizer/discussions/333).