### PR TITLE
Reset PVC metrics when encoded size exceeds threshold

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ var config struct {
 	development               bool
 	zapOpts                   zap.Options
 	pvcMutatingWebhookEnabled bool
+	metricsResetSizeThreshold uint64
 }
 
 // rootCmd represents the base command when called without any subcommands
@@ -61,6 +62,8 @@ func init() {
 	fs.BoolVar(&config.development, "development", false, "Use development logger config")
 	fs.BoolVar(&config.pvcMutatingWebhookEnabled, "pvc-mutating-webhook-enabled", true,
 		"Enable the pvc mutating webhook endpoint")
+	fs.Uint64Var(&config.metricsResetSizeThreshold, "metrics-reset-size-threshold", 0,
+		"Reset metrics when their encoded size exceeds this threshold in bytes. Set 0 to disable. (default 0)")
 
 	goflags := flag.NewFlagSet("zap", flag.ExitOnError)
 	config.zapOpts.BindFlags(goflags)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -134,7 +134,7 @@ func subMain() error {
 
 	pvcAutoresizer := runners.NewPVCAutoresizer(metricsClient, mgr.GetClient(),
 		ctrl.Log.WithName("pvc-autoresizer"),
-		config.watchInterval, mgr.GetEventRecorderFor("pvc-autoresizer"))
+		config.watchInterval, mgr.GetEventRecorderFor("pvc-autoresizer"), config.metricsResetSizeThreshold)
 	if err := mgr.Add(pvcAutoresizer); err != nil {
 		setupLog.Error(err, "unable to add autoresier to manager")
 		return err

--- a/internal/metrics/resizer_test.go
+++ b/internal/metrics/resizer_test.go
@@ -15,6 +15,69 @@ func TestResizerSuccessResizeTotal(t *testing.T) {
 	}
 }
 
+func TestResetMetricsIfExceedsThreshold(t *testing.T) {
+	ResizerSuccessResizeTotal.Increment("pvc-a", "ns-a")
+	ResizerFailedResizeTotal.Increment("pvc-a", "ns-a")
+	ResizerLimitReachedTotal.Increment("pvc-a", "ns-a")
+
+	before := testutil.CollectAndCount(resizerSuccessResizeTotal)
+	if before == 0 {
+		t.Fatalf("expected metrics before reset")
+	}
+
+	size, err := currentMetricsSizeBytes()
+	if err != nil {
+		t.Fatalf("failed to get metrics size: %v", err)
+	}
+
+	if size == 0 {
+		t.Fatalf("expected metrics size to be > 0")
+	}
+
+	reset, err := ResetMetricsIfExceedsThreshold(size - 1)
+	if err != nil {
+		t.Fatalf("ResetMetricsIfExceedsThreshold returned error: %v", err)
+	}
+	if !reset {
+		t.Fatalf("expected reset to occur")
+	}
+
+	after := testutil.CollectAndCount(resizerSuccessResizeTotal)
+	if after != 0 {
+		t.Fatalf("expected metrics to be cleared, got %d", after)
+	}
+}
+
+func TestResetMetricsIfExceedsThreshold_NoResetBelowThreshold(t *testing.T) {
+	resetLabelHeavyMetrics()
+	defer resetLabelHeavyMetrics()
+
+	ResizerSuccessResizeTotal.Increment("pvc-a", "ns-a")
+
+	before := testutil.CollectAndCount(resizerSuccessResizeTotal)
+	if before == 0 {
+		t.Fatalf("expected metrics before reset")
+	}
+
+	size, err := currentMetricsSizeBytes()
+	if err != nil {
+		t.Fatalf("failed to get metrics size: %v", err)
+	}
+
+	reset, err := ResetMetricsIfExceedsThreshold(size + 100)
+	if err != nil {
+		t.Fatalf("ResetMetricsIfExceedsThreshold returned error: %v", err)
+	}
+	if reset {
+		t.Fatalf("expected reset to not occur")
+	}
+
+	after := testutil.CollectAndCount(resizerSuccessResizeTotal)
+	if after != before {
+		t.Fatalf("expected metrics to remain, got %d (want %d)", after, before)
+	}
+}
+
 func TestResizerFailedResizeTotal(t *testing.T) {
 	ResizerFailedResizeTotal.Increment("my-test-pvc", "my-test-namespace")
 	actual := testutil.ToFloat64(resizerFailedResizeTotal)

--- a/internal/runners/suite_test.go
+++ b/internal/runners/suite_test.go
@@ -82,14 +82,14 @@ var _ = BeforeSuite(func() {
 
 	pvcAutoresizer := NewPVCAutoresizer(&promClient, mgr.GetClient(),
 		logf.Log.WithName("pvc-autoresizer"),
-		1*time.Second, mgr.GetEventRecorderFor("pvc-autoresizer"))
+		1*time.Second, mgr.GetEventRecorderFor("pvc-autoresizer"), 100*1024*1024)
 	err = mgr.Add(pvcAutoresizer)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Add pvcAutoresizer with FakeClientWrapper for metrics tests
 	pvcAutoresizer2 := NewPVCAutoresizer(&promClient, NewFakeClientWrapper(mgr.GetClient()),
 		logf.Log.WithName("pvc-autoresizer2"),
-		1*time.Second, mgr.GetEventRecorderFor("pvc-autoresizer2"))
+		1*time.Second, mgr.GetEventRecorderFor("pvc-autoresizer2"), 100*1024*1024)
 	err = mgr.Add(pvcAutoresizer2)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
This PR is a kaizen.

This change adds a safeguard that resets metrics when their encoded size exceeds a configurable capacity, introduced via the --metrics-reset-size-threshold flag (default 100 MiB), preventing unbounded metric growth. Helm chart updates are deferred to a follow‑up PR because updating the chart alone would fail ct install on the current default image; the chart will be updated after the pvc‑autoresizer image is published with this change.