### PR TITLE
fix: ensure controller pods always run

### DIFF
--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -41,10 +41,11 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | controller.args.useK8sMetricsApi | bool | `false` | Use Kubernetes metrics API instead of Prometheus. Used as "--use-k8s-metrics-api" option |
 | controller.nodeSelector | object | `{}` | Map of key-value pairs for scheduling pods on specific nodes. |
 | controller.podAnnotations | object | `{}` | Annotations to be added to controller pods. |
+| controller.podDisruptionBudget.enabled | bool | `true` | Specify podDisruptionBudget enabled. |
 | controller.podLabels | object | `{}` | Pod labels to be added to controller pods. |
 | controller.podSecurityContext | object | `{}` | Security Context to be applied to the controller pods. |
 | controller.priorityClassName | string | `""` | Priority class name to be applied to the controller pods. |
-| controller.replicas | int | `1` | Specify the number of replicas of the controller Pod. |
+| controller.replicas | int | `2` | Specify the number of replicas of the controller Pod. |
 | controller.resources | object | `{"requests":{"cpu":"100m","memory":"20Mi"}}` | Specify resources. |
 | controller.securityContext | object | `{}` | Security Context to be applied to the controller container within controller pods. |
 | controller.terminationGracePeriodSeconds | string | `nil` | Specify terminationGracePeriodSeconds. |

--- a/charts/pvc-autoresizer/templates/controller/poddisruptionbudget.yaml
+++ b/charts/pvc-autoresizer/templates/controller/poddisruptionbudget.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.controller.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "pvc-autoresizer.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "pvc-autoresizer.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -11,7 +11,7 @@ image:
 
 controller:
   # controller.replicas -- Specify the number of replicas of the controller Pod.
-  replicas: 1
+  replicas: 2
 
   args:
     # controller.args.useK8sMetricsApi -- Use Kubernetes metrics API instead of Prometheus.
@@ -47,6 +47,10 @@ controller:
 
   # controller.podAnnotations -- Annotations to be added to controller pods.
   podAnnotations: {}
+
+  podDisruptionBudget:
+    # controller.podDisruptionBudget.enabled -- Specify podDisruptionBudget enabled.
+    enabled: true
 
   # controller.podSecurityContext -- Security Context to be applied to the controller pods.
   podSecurityContext: {}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -112,7 +112,7 @@ var _ = BeforeSuite(func() {
 			return err
 		}
 
-		if deploy.Status.AvailableReplicas != 1 {
+		if deploy.Status.AvailableReplicas == 0 {
 			return errors.New("pvc-autoresizer-controller is not available yet")
 		}
 


### PR DESCRIPTION
Set replicas to 2 and add a PodDisruptionBudget to ensure the controller
pod always runs, preventing webhook unavailability that blocks PVC creation.
