### PR TITLE
add metrics reset size threshold to Helm chart

### DIFF
--- a/charts/pvc-autoresizer/Chart.yaml
+++ b/charts/pvc-autoresizer/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.1
+version: 0.15.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -36,6 +36,7 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | controller.annotations | object | `{}` | Annotations to be added to controller deployment. |
 | controller.args.additionalArgs | list | `[]` | Specify additional args. |
 | controller.args.interval | string | `"10s"` | Specify interval to monitor pvc capacity. Used as "--interval" option |
+| controller.args.metricsResetSizeThreshold | int | `0` | Reset metrics when their encoded size exceeds this threshold in bytes. Set 0 to disable. Used as "--metrics-reset-size-threshold" option |
 | controller.args.namespaces | list | `[]` | Specify namespaces to control the pvcs of. Empty for all namespaces. Used as "--namespaces" option |
 | controller.args.prometheusURL | string | `"http://prometheus-prometheus-oper-prometheus.prometheus.svc:9090"` | Specify Prometheus URL to query volume stats. Used as "--prometheus-url" option |
 | controller.args.useK8sMetricsApi | bool | `false` | Use Kubernetes metrics API instead of Prometheus. Used as "--use-k8s-metrics-api" option |

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -43,6 +43,9 @@ spec:
           {{- if .Values.controller.args.namespaces }}
             - --namespaces={{ join "," .Values.controller.args.namespaces }}
           {{- end }}
+          {{- if ne .Values.controller.args.metricsResetSizeThreshold nil }}
+            - --metrics-reset-size-threshold={{ .Values.controller.args.metricsResetSizeThreshold }}
+          {{- end }}
           {{- with .Values.controller.args.additionalArgs -}}
             {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -30,6 +30,10 @@ controller:
     # Used as "--interval" option
     interval: 10s
 
+    # controller.args.metricsResetSizeThreshold -- Reset metrics when their encoded size exceeds this threshold in bytes. Set 0 to disable.
+    # Used as "--metrics-reset-size-threshold" option
+    metricsResetSizeThreshold: 0
+
     # controller.args.additionalArgs -- Specify additional args.
     additionalArgs: []
 


### PR DESCRIPTION
39ace385e175 introduced the --metrics-reset-size-threshold flag to reset oversized metrics. This change wires that flag into the Helm chart updates the values/README, and bumps the chart version so users can configure the threshold via chart values.