### PR TITLE
Fix template variable scope for serviceAccountName

### DIFF
--- a/charts/pvc-autoresizer/templates/controller/rolebinding.yaml
+++ b/charts/pvc-autoresizer/templates/controller/rolebinding.yaml
@@ -29,6 +29,6 @@ roleRef:
   name: {{ template "pvc-autoresizer.fullname" $ }}-controller
 subjects:
 - kind: ServiceAccount
-  name: {{ template "pvc-autoresizer.serviceAccountName" . }}
+  name: {{ template "pvc-autoresizer.serviceAccountName" $ }}
   namespace: {{ $.Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
Fix regression introduced by https://github.com/topolvm/pvc-autoresizer/pull/358