### PR TITLE
support imagePullSecrets

### DIFF
--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -51,6 +51,7 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | controller.terminationGracePeriodSeconds | string | `nil` | Specify terminationGracePeriodSeconds. |
 | controller.tolerations | object | `{}` | Ensure pods are not scheduled on inappropriate nodes. |
 | image.pullPolicy | string | `nil` | pvc-autoresizer image pullPolicy. |
+| image.pullSecrets | list | `[]` | List of image pull secret names to use for pulling the pvc-autoresizer image (applied to the pod spec). |
 | image.repository | string | `"ghcr.io/topolvm/pvc-autoresizer"` | pvc-autoresizer image repository to use. |
 | image.tag | string | `{{ .Chart.AppVersion }}` | pvc-autoresizer image tag to use. |
 | podMonitor | object | `{"additionalLabels":{},"enabled":false,"interval":"","metricRelabelings":[],"namespace":"","relabelings":[],"scheme":"http","scrapeTimeout":""}` | deploy a PodMonitor. This is not tested in CI so make sure to test it yourself. |
@@ -64,6 +65,7 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | podMonitor.scrapeTimeout | string | `""` | The timeout after which the scrape is ended |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Controls the automatic mounting of ServiceAccount API credentials. |
 | serviceAccount.enabled | bool | `true` | Creates a ServiceAccount for the controller deployment. |
+| serviceAccount.imagePullSecrets | list | `[]` | List of image pull secret names to attach to the ServiceAccount (applied to all pods using the SA). |
 | serviceAccount.name | string | `""` | The name for the newly created or existing service account. |
 | webhook.caBundle | string | `nil` | Specify the certificate to be used for AdmissionWebhook. |
 | webhook.certificate.dnsDomain | string | `"cluster.local"` | Cluster DNS domain (required for requesting TLS certificates). |

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "pvc-autoresizer.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.controller.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
       {{- end }}

--- a/charts/pvc-autoresizer/templates/controller/serviceaccount.yaml
+++ b/charts/pvc-autoresizer/templates/controller/serviceaccount.yaml
@@ -7,4 +7,8 @@ metadata:
   labels:
     {{- include "pvc-autoresizer.labels" . | nindent 4 }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -9,6 +9,10 @@ image:
   # image.pullPolicy -- pvc-autoresizer image pullPolicy.
   pullPolicy:  # Always
 
+  # image.pullSecrets -- List of image pull secret names to use for pulling the pvc-autoresizer image (applied to the pod spec).
+  pullSecrets: []
+  # - name: my-registry-secret
+
 controller:
   # controller.replicas -- Specify the number of replicas of the controller Pod.
   replicas: 2
@@ -163,3 +167,6 @@ serviceAccount:
   automountServiceAccountToken: true
   # serviceAccount.name -- The name for the newly created or existing service account.
   name: ""
+  # serviceAccount.imagePullSecrets -- List of image pull secret names to attach to the ServiceAccount (applied to all pods using the SA).
+  imagePullSecrets: []
+  # - name: my-registry-secret


### PR DESCRIPTION
Adds the ability to define a `imagePullSecrets` for the controller deployment directly and/or the `serviceAccount` created by the chart. 

fixes https://github.com/topolvm/pvc-autoresizer/issues/364