### PR TITLE
Add support for PodMonitor honorLabels

### DIFF
--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -53,9 +53,10 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | image.pullPolicy | string | `nil` | pvc-autoresizer image pullPolicy. |
 | image.repository | string | `"ghcr.io/topolvm/pvc-autoresizer"` | pvc-autoresizer image repository to use. |
 | image.tag | string | `{{ .Chart.AppVersion }}` | pvc-autoresizer image tag to use. |
-| podMonitor | object | `{"additionalLabels":{},"enabled":false,"interval":"","metricRelabelings":[],"namespace":"","relabelings":[],"scheme":"http","scrapeTimeout":""}` | deploy a PodMonitor. This is not tested in CI so make sure to test it yourself. |
+| podMonitor | object | `{"additionalLabels":{},"enabled":false,"honorLabels":false,"interval":"","metricRelabelings":[],"namespace":"","relabelings":[],"scheme":"http","scrapeTimeout":""}` | deploy a PodMonitor. This is not tested in CI so make sure to test it yourself. |
 | podMonitor.additionalLabels | object | `{}` | Additional labels that can be used so PodMonitor will be discovered by Prometheus. |
 | podMonitor.enabled | bool | `false` | If true, creates a Prometheus Operator PodMonitor. |
+| podMonitor.honorLabels | bool | `false` | If true, preserves the metric's labels when they collide with the target's labels. |
 | podMonitor.interval | string | `""` | Interval that Prometheus scrapes metrics. |
 | podMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion. |
 | podMonitor.namespace | string | `""` | Namespace which Prometheus is running in. |

--- a/charts/pvc-autoresizer/templates/controller/podmonitor.yaml
+++ b/charts/pvc-autoresizer/templates/controller/podmonitor.yaml
@@ -25,6 +25,9 @@ spec:
       {{- if .Values.podMonitor.scheme }}
       scheme: {{ .Values.podMonitor.scheme }}
       {{- end }}
+      {{- with .Values.podMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
       {{- with .Values.podMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -109,6 +109,8 @@ podMonitor:
   enabled: false
   # podMonitor.scheme -- Scheme to use for scraping.
   scheme: http
+  # podMonitor.honorLabels -- If true, preserves the metric's labels when they collide with the target's labels.
+  honorLabels: false
   # podMonitor.interval -- Interval that Prometheus scrapes metrics.
   interval: ""
   # podMonitor.scrapeTimeout -- The timeout after which the scrape is ended


### PR DESCRIPTION
Adds support for `honorLabels`. This is particularly useful because the metrics export a `namespace` label, which is also commonly injected when scraping.

Without it, we end up with an `exported_namespace` label instead, and I feel like most people would rather match on `namespace` as the target PVCs namespaces are more relevant.

See the [PrometheusOperator API reference](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMetricsEndpoint)

