### PR TITLE
Copy CA certs to enable TLS connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -ldflags="-w -s" -a -o pvc-autor
 # Stage2: setup runtime container
 FROM scratch
 WORKDIR /
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /workspace/pvc-autoresizer .
 EXPOSE 8080
 USER 10000:10000


### PR DESCRIPTION
Without CA certificates in the Docker image POSTs to Prometheus fail with certificate verification errors.

Example error message:
tls: failed to verify certificate: x509: certificate signed by unknown authority"