### PR TITLE
Remove user name comments from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,2 @@
-# Maintainers can approve and merge PRs.
-# @toshipp: Toshikuni Fukaya
-# @llamerada-jp: Yuji Ito
-# @satoru-takeuchi: Satoru Takeuchi
-# @cupnes: Yuma Ohgami
-# @daichimukai: Daichi Mukai
-# @peng225: Shinya Hayashi
-# @pluser: ESASHIKA Kaoru
-# @ushitora-anqou: Ryotaro Banno
+# reviewers can approve and merge PRs.
 * @topolvm/reviewers


### PR DESCRIPTION
It can be seen on the GitHub Teams web UI.