### PR TITLE
ISSUE_TEMPLATE: add kubebuilder to the TODO list

### DIFF
--- a/.github/ISSUE_TEMPLATE/update_supporting_kubernetes.md
+++ b/.github/ISSUE_TEMPLATE/update_supporting_kubernetes.md
@@ -25,6 +25,8 @@ Must update Kubernetes with each new version of Kubernetes.
   - https://github.com/kubernetes-sigs/controller-tools/releases
 - [ ] topolvm
   - https://github.com/topolvm/topolvm/blob/main/CHANGELOG.md
+- [ ] kubebuilder
+  - https://github.com/kubernetes-sigs/kubebuilder/releases
 
 ### Release notes check
 


### PR DESCRIPTION
The kubebuilder version compatible with the new Kubernetes version is
now required in the maintenance.md.