### PR TITLE
fix: grant access to events.k8s.io events

### DIFF
--- a/charts/pvc-autoresizer/templates/controller/clusterrole.yaml
+++ b/charts/pvc-autoresizer/templates/controller/clusterrole.yaml
@@ -31,6 +31,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - ""
   resources:
   - persistentvolumeclaims

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,6 +24,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses

--- a/internal/runners/pvc_autoresizer.go
+++ b/internal/runners/pvc_autoresizer.go
@@ -24,6 +24,7 @@ import (
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 const resizeEnableIndexKey = ".metadata.annotations[resize.topolvm.io/enabled]"
 const storageClassNameIndexKey = ".spec.storageClassName"


### PR DESCRIPTION
## Summary

- grant the controller permission to create and patch `events.k8s.io` events
- regenerate the controller ClusterRole and mirror the rule in the Helm chart

Fixes #389

## Testing

- `make check-uncommitted`
- `make lint`
- `ENVTEST_KUBERNETES_VERSION=1.35.0 go test -race -v -count 1 ./... --timeout=120s`
- `helm lint charts/pvc-autoresizer`
- `helm template test charts/pvc-autoresizer`
