### PR TITLE
feat: add --prometheus-label-selector flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ In addition, configure scraping as follows:
 You must configure how `pvc-autoresizer` obtains volume usage metrics. Two supported methods are described below.
 
 - Prometheus (HTTP endpoint): set the `--prometheus-url` argument to point to your Prometheus server endpoint.
+  If the endpoint aggregates metrics from multiple clusters (e.g. a global Mimir or Thanos), also set
+  `--prometheus-label-selector` with PromQL label matchers (e.g. `cluster="prod"`) so the volume stats
+  queries only return series for the cluster this controller manages. Without it, a PVC with the same
+  namespace and name in another cluster can silently supply stats for the local PVC.
 - Kubernetes Metrics API: enable use of the cluster Metrics API by setting the `--use-k8s-metrics-api=true` argument.
 
 `pvc-autoresizer` can be deployed to a Kubernetes cluster via `helm`.

--- a/charts/pvc-autoresizer/README.md
+++ b/charts/pvc-autoresizer/README.md
@@ -37,6 +37,7 @@ helm upgrade --create-namespace --namespace pvc-autoresizer -i pvc-autoresizer -
 | controller.args.additionalArgs | list | `[]` | Specify additional args. |
 | controller.args.interval | string | `"10s"` | Specify interval to monitor pvc capacity. Used as "--interval" option |
 | controller.args.namespaces | list | `[]` | Specify namespaces to control the pvcs of. Empty for all namespaces. Used as "--namespaces" option |
+| controller.args.prometheusLabelSelector | string | `""` | Comma-separated PromQL label matchers appended to the volume stats queries, to restrict results when the Prometheus endpoint aggregates multiple clusters. Used as "--prometheus-label-selector" option |
 | controller.args.prometheusURL | string | `"http://prometheus-prometheus-oper-prometheus.prometheus.svc:9090"` | Specify Prometheus URL to query volume stats. Used as "--prometheus-url" option |
 | controller.args.useK8sMetricsApi | bool | `false` | Use Kubernetes metrics API instead of Prometheus. Used as "--use-k8s-metrics-api" option |
 | controller.nodeSelector | object | `{}` | Map of key-value pairs for scheduling pods on specific nodes. |

--- a/charts/pvc-autoresizer/templates/controller/deployment.yaml
+++ b/charts/pvc-autoresizer/templates/controller/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             - /pvc-autoresizer
           args:
             - --prometheus-url={{ .Values.controller.args.prometheusURL }}
+          {{- if .Values.controller.args.prometheusLabelSelector }}
+            - --prometheus-label-selector={{ .Values.controller.args.prometheusLabelSelector }}
+          {{- end }}
             - --interval={{ .Values.controller.args.interval }}
           {{- if .Values.controller.args.useK8sMetricsApi }}
             - --use-k8s-metrics-api={{ .Values.controller.args.useK8sMetricsApi }}

--- a/charts/pvc-autoresizer/values.yaml
+++ b/charts/pvc-autoresizer/values.yaml
@@ -25,6 +25,11 @@ controller:
     # Used as "--prometheus-url" option
     prometheusURL: http://prometheus-prometheus-oper-prometheus.prometheus.svc:9090
 
+    # controller.args.prometheusLabelSelector -- Comma-separated PromQL label matchers appended to the
+    # volume stats queries, to restrict results when the Prometheus endpoint aggregates multiple clusters.
+    # Used as "--prometheus-label-selector" option
+    prometheusLabelSelector: ""
+
     # controller.args.namespaces -- Specify namespaces to control the pvcs of. Empty for all namespaces.
     # Used as "--namespaces" option
     namespaces: []

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ var config struct {
 	namespaces                []string
 	watchInterval             time.Duration
 	prometheusURL             string
+	prometheusLabelSelector   string
 	useK8sMetricsApi          bool
 	skipAnnotation            bool
 	development               bool
@@ -57,6 +58,10 @@ func init() {
 		"Namespaces to resize PersistentVolumeClaims within. Empty for all namespaces.")
 	fs.DurationVar(&config.watchInterval, "interval", 1*time.Minute, "Interval to monitor pvc capacity.")
 	fs.StringVar(&config.prometheusURL, "prometheus-url", "", "Prometheus URL to query volume stats.")
+	fs.StringVar(&config.prometheusLabelSelector, "prometheus-label-selector", "",
+		"Optional comma-separated PromQL label matchers (e.g. cluster=\"prod\") appended to the volume stats "+
+			"queries. Use when the Prometheus endpoint aggregates metrics from multiple clusters, to restrict "+
+			"results to the cluster this controller manages.")
 	fs.BoolVar(&config.useK8sMetricsApi, "use-k8s-metrics-api", false, "Use Kubernetes metrics API instead of Prometheus")
 	fs.BoolVar(&config.skipAnnotation, "no-annotation-check", false, "Skip annotation check for StorageClass")
 	fs.BoolVar(&config.development, "development", false, "Use development logger config")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -116,7 +116,7 @@ func subMain() error {
 	if config.useK8sMetricsApi {
 		metricsClient, err = runners.NewK8sMetricsApiClient()
 	} else if config.prometheusURL != "" {
-		metricsClient, err = runners.NewPrometheusClient(config.prometheusURL)
+		metricsClient, err = runners.NewPrometheusClient(config.prometheusURL, config.prometheusLabelSelector)
 	} else {
 		setupLog.Error(err, "enable use-k8s-metrics-api or provide prometheus-url")
 		return err

--- a/internal/runners/metrics_client_test.go
+++ b/internal/runners/metrics_client_test.go
@@ -40,7 +40,7 @@ var _ = Describe("test prometheusClient", func() {
 		ts := httptest.NewServer(http.HandlerFunc(http.NotFound))
 		defer ts.Close()
 
-		c, err := NewPrometheusClient(ts.URL)
+		c, err := NewPrometheusClient(ts.URL, "")
 		Expect(err).ToNot(HaveOccurred())
 		_, err = c.GetMetrics(context.TODO())
 		Expect(err).To(HaveOccurred())

--- a/internal/runners/prometheus_client.go
+++ b/internal/runners/prometheus_client.go
@@ -12,8 +12,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// NewPrometheusClient returns a new prometheusClient
-func NewPrometheusClient(url string) (MetricsClient, error) {
+// NewPrometheusClient returns a new prometheusClient.
+// labelSelector is an optional comma-separated list of PromQL label matchers
+// (e.g. `cluster="prod",env!="dev"`) appended to every volume stats query.
+// This is useful when the Prometheus-compatible endpoint aggregates metrics
+// from multiple clusters: without a selector, same-named PVCs from another
+// cluster would be indistinguishable because results are keyed by namespace
+// and PVC name only.
+func NewPrometheusClient(url string, labelSelector string) (MetricsClient, error) {
 	client, err := api.NewClient(api.Config{
 		Address: url,
 	})
@@ -24,33 +30,35 @@ func NewPrometheusClient(url string) (MetricsClient, error) {
 
 	return &prometheusClient{
 		prometheusAPI: v1api,
+		labelSelector: labelSelector,
 	}, nil
 }
 
 type prometheusClient struct {
 	prometheusAPI prometheusv1.API
+	labelSelector string
 }
 
 // GetMetrics implements MetricsClient.GetMetrics
 func (c *prometheusClient) GetMetrics(ctx context.Context) (map[types.NamespacedName]*VolumeStats, error) {
 	volumeStatsMap := make(map[types.NamespacedName]*VolumeStats)
 
-	availableBytes, err := c.getMetricValues(ctx, volumeAvailableQuery)
+	availableBytes, err := c.getMetricValues(ctx, c.buildQuery(volumeAvailableQuery))
 	if err != nil {
 		return nil, err
 	}
 
-	capacityBytes, err := c.getMetricValues(ctx, volumeCapacityQuery)
+	capacityBytes, err := c.getMetricValues(ctx, c.buildQuery(volumeCapacityQuery))
 	if err != nil {
 		return nil, err
 	}
 
-	availableInodeSize, err := c.getMetricValues(ctx, inodesAvailableQuery)
+	availableInodeSize, err := c.getMetricValues(ctx, c.buildQuery(inodesAvailableQuery))
 	if err != nil {
 		return nil, err
 	}
 
-	capacityInodeSize, err := c.getMetricValues(ctx, inodesCapacityQuery)
+	capacityInodeSize, err := c.getMetricValues(ctx, c.buildQuery(inodesCapacityQuery))
 	if err != nil {
 		return nil, err
 	}
@@ -76,6 +84,15 @@ func (c *prometheusClient) GetMetrics(ctx context.Context) (map[types.Namespaced
 	}
 
 	return volumeStatsMap, nil
+}
+
+// buildQuery returns the PromQL query for a metric name, applying the
+// configured label selector if one is set.
+func (c *prometheusClient) buildQuery(metricName string) string {
+	if c.labelSelector == "" {
+		return metricName
+	}
+	return fmt.Sprintf("%s{%s}", metricName, c.labelSelector)
 }
 
 func (c *prometheusClient) getMetricValues(ctx context.Context, query string) (map[types.NamespacedName]int64, error) {

--- a/internal/runners/prometheus_client_test.go
+++ b/internal/runners/prometheus_client_test.go
@@ -1,0 +1,41 @@
+package runners
+
+import "testing"
+
+func TestPrometheusClientBuildQuery(t *testing.T) {
+	testCases := []struct {
+		name          string
+		labelSelector string
+		metricName    string
+		expected      string
+	}{
+		{
+			name:          "no selector returns bare metric name",
+			labelSelector: "",
+			metricName:    volumeAvailableQuery,
+			expected:      `kubelet_volume_stats_available_bytes`,
+		},
+		{
+			name:          "single matcher",
+			labelSelector: `cluster="prod"`,
+			metricName:    volumeAvailableQuery,
+			expected:      `kubelet_volume_stats_available_bytes{cluster="prod"}`,
+		},
+		{
+			name:          "multiple matchers",
+			labelSelector: `cluster="prod",env!="dev"`,
+			metricName:    inodesCapacityQuery,
+			expected:      `kubelet_volume_stats_inodes{cluster="prod",env!="dev"}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &prometheusClient{labelSelector: tc.labelSelector}
+			got := c.buildQuery(tc.metricName)
+			if got != tc.expected {
+				t.Errorf("buildQuery(%q) = %q, want %q", tc.metricName, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When `--prometheus-url` points at an endpoint that aggregates metrics from multiple clusters (e.g. a global Mimir/Thanos/VictoriaMetrics), the volume stats queries return series for every cluster, and results are keyed by namespace and PVC name only. A PVC with the same name in another cluster then silently supplies stats for the local PVC, so resize decisions are made from another cluster's disk usage.

The new flag accepts comma-separated PromQL label matchers, e.g. `--prometheus-label-selector='cluster="prod"'`, which are appended to the four `kubelet_volume_stats_*` queries to restrict results to the cluster the controller manages. Empty (default) keeps the current behavior.