### PR TITLE
Recycle Prometheus client connections to avoid querying stale backends

### DIFF
--- a/internal/runners/prometheus_client.go
+++ b/internal/runners/prometheus_client.go
@@ -3,7 +3,6 @@ package runners
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"time"
 
@@ -16,24 +15,11 @@ import (
 
 // NewPrometheusClient returns a new prometheusClient
 func NewPrometheusClient(url string) (MetricsClient, error) {
-	// api.DefaultRoundTripper leaves IdleConnTimeout unset (0), so a keep-alive
-	// connection to a Service ClusterIP is held open indefinitely. kube-proxy routes
-	// per connection and never breaks an established one; it only load-balances new
-	// connections onto the current endpoints. So when a Service is repointed while its
-	// old backend pods stay up (a selector/endpoint change — not a pod deletion, which
-	// would reset the connection and force a re-dial), a reused connection keeps hitting
-	// the old backend and the client silently reads stale data. Disable keep-alives so
-	// every query re-dials and is routed to a current endpoint; the query volume is only
-	// a few requests per reconcile interval, so re-dialing per request is cheap.
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout: 10 * time.Second,
-		DisableKeepAlives:   true,
-	}
+	// kube-proxy pins each keep-alive connection to one backend, so after the Prometheus
+	// Service is repointed a reused connection keeps reading the stale backend; disable
+	// keep-alives to re-dial per query. Clone the default transport to keep its other fields.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableKeepAlives = true
 	client, err := api.NewClient(api.Config{
 		Address:      url,
 		RoundTripper: transport,

--- a/internal/runners/prometheus_client.go
+++ b/internal/runners/prometheus_client.go
@@ -3,6 +3,8 @@ package runners
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
@@ -14,8 +16,27 @@ import (
 
 // NewPrometheusClient returns a new prometheusClient
 func NewPrometheusClient(url string) (MetricsClient, error) {
+	// api.DefaultRoundTripper leaves IdleConnTimeout unset (0), so a keep-alive
+	// connection to a Service ClusterIP is held open indefinitely. kube-proxy routes
+	// per connection and never breaks an established one; it only load-balances new
+	// connections onto the current endpoints. So when a Service is repointed while its
+	// old backend pods stay up (a selector/endpoint change — not a pod deletion, which
+	// would reset the connection and force a re-dial), a reused connection keeps hitting
+	// the old backend and the client silently reads stale data. Disable keep-alives so
+	// every query re-dials and is routed to a current endpoint; the query volume is only
+	// a few requests per reconcile interval, so re-dialing per request is cheap.
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout: 10 * time.Second,
+		DisableKeepAlives:   true,
+	}
 	client, err := api.NewClient(api.Config{
-		Address: url,
+		Address:      url,
+		RoundTripper: transport,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`NewPrometheusClient` uses client_golang's `api.DefaultRoundTripper`, whose `http.Transport` leaves `IdleConnTimeout` unset (0), so its keep-alive connection is never recycled, and the client is a long-lived singleton, so it holds a single connection to the configured URL for the pod's lifetime.

When that URL is a k8s Service (ClusterIP) that gets repointed to a different backend while the old backend pods stay up (an endpoint/selector change, not a pod deletion, which would reset the connection and force a re-dial), `kube-proxy` never breaks the established connection and only routes new connections to the current endpoints. The client keeps querying the old backend indefinitely. If that backend still responds but no longer has the volume-stats series, every query returns an empty HTTP 200,  so `pvcautoresizer_metrics_client_fail_total` stays 0, the controller logs `failed to get volume stats`, and it silently stops resizing every PVC.