### PR TITLE
dependabot: Add a gomod configuration to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,20 @@ updates:
           - "*"
     cooldown:
       default-days: 14
+  - package-ecosystem: "gomod"
+    directory: "/"
+    rebase-strategy: "disabled"
+    schedule:
+      interval: "monthly"
+    groups:
+      gomod-dependencies-update:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 14
+    ignore:
+      - dependency-name: "github.com/prometheus/*"
+      - dependency-name: "k8s.io/api"
+      - dependency-name: "k8s.io/apimachinery"
+      - dependency-name: "k8s.io/client-go"
+      - dependency-name: "sigs.k8s.io/controller-runtime"


### PR DESCRIPTION
I tried to exclude K8s-related packages from dependabot, I found that Go lang wasn't listed as a target, so I added it with the exclusion settings.